### PR TITLE
[NO-TICKET] Enable default value support for union types

### DIFF
--- a/lib/src/parsers/schemaprop-parser.ts
+++ b/lib/src/parsers/schemaprop-parser.ts
@@ -196,7 +196,8 @@ export const propTypeMap = new Map<
         TypeKind.STRING,
         TypeKind.BOOLEAN,
         TypeKind.ARRAY,
-        TypeKind.OBJECT
+        TypeKind.OBJECT,
+        TypeKind.UNION
       ]
     }
   ],


### PR DESCRIPTION
## Description, Motivation and Context

Support for the `@default` annotation does already exist in SPOT, but only for certain types. This PR enables the `@default` annotation for union types, allowing default values for enums.

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR
