### PR TITLE
[NT] Change to use ES module imports rather than CommonJS

### DIFF
--- a/cli/src/commands/generate.ts
+++ b/cli/src/commands/generate.ts
@@ -1,5 +1,5 @@
 import { Command, flags } from "@oclif/command";
-import { prompt } from "inquirer";
+import inquirer from "inquirer";
 import YAML from "js-yaml";
 import path from "path";
 import { Contract } from "../../../lib/src/definitions";
@@ -46,7 +46,7 @@ export default class Generate extends Command {
 
     if (!generator) {
       generator = (
-        await prompt<{
+        await inquirer.prompt<{
           Generator: string;
         }>({
           name: "Generator",
@@ -69,7 +69,7 @@ export default class Generate extends Command {
 
     if (!language) {
       language = (
-        await prompt<{
+        await inquirer.prompt<{
           Language: string;
         }>({
           name: "Language",
@@ -92,7 +92,7 @@ export default class Generate extends Command {
 
     if (!outDir) {
       outDir = (
-        await prompt<{
+        await inquirer.prompt<{
           "Output destination": string;
         }>({
           name: "Output destination",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
     // Optional chaining was introduced in es2020. This project supports node >= 12. Only node >= 14 supports optional chaining.
-    "target": "es2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "target": "es2020",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "es2020",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */


### PR DESCRIPTION
## Description, Motivation and Context

Most of the outstanding dependabot third-party library version bumps are failing CI as they require the built application/library to use ES Module imports rather than CommonJS imports.

This PR switches this codebase over to use ES Module import rather than CommonJS imports.

## Checklist:

- [x] I've added/updated tests to cover my changes
- [x] I've created an issue associated with this PR
