### PR TITLE
feat(ACQ-6385): increase pnpm security settings for @airtasker/spot

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,11 +86,5 @@
     "eslint:fix": "eslint . --fix --ext .js,.ts,.tsx",
     "prettier:fix": "prettier --write \"**/*.js\" \"**/*.ts\" \"**/*.tsx\""
   },
-  "pnpm": {
-    "overrides": {
-      "jsonpath-plus": "^10.2",
-      "immer": "^9.0.6"
-    }
-  },
   "packageManager": "pnpm@10.28.1"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,11 @@
 packages:
   - 'docs'
 
-# Security: 7-day delay before using newly published packages (10,080 minutes)
+# Supply Chain Security Configuration
+# Documentation: https://airtasker.atlassian.net/wiki/spaces/ENG/pages/4767645728/JavaScript+Package+Manager+Configuration
+# Reference: https://pnpm.io/supply-chain-security
+
+strictDepBuilds: true
+blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude:
-  - '@airtasker/*'
+minimumReleaseAgeExclude: '@airtasker/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,9 @@
 packages:
-  - 'docs'
+  - "docs"
+
+overrides:
+  jsonpath-plus: "^10.2"
+  immer: "^9.0.6"
 
 # Supply Chain Security Configuration
 # Documentation: https://airtasker.atlassian.net/wiki/spaces/ENG/pages/4767645728/JavaScript+Package+Manager+Configuration
@@ -8,4 +12,6 @@ packages:
 strictDepBuilds: true
 blockExoticSubdeps: true
 minimumReleaseAge: 10080
-minimumReleaseAgeExclude: '@airtasker/*'
+minimumReleaseAgeExclude: "@airtasker/*"
+allowBuilds:
+  core-js: false


### PR DESCRIPTION
## Description, Motivation and Context

Apply supply chain security configuration to `pnpm-workspace.yaml` per the [JavaScript Package Manager Configuration](https://airtasker.atlassian.net/wiki/spaces/ENG/pages/4767645728/JavaScript+Package+Manager+Configuration) guide.

- Add `strictDepBuilds: true` — installation fails if any unlisted package attempts to run a lifecycle script
  - Blocks corejs from running post install script
- Add `blockExoticSubdeps: true` — blocks transitive dependencies from non-registry sources
- Normalise `minimumReleaseAgeExclude` to inline string format
- Moves overrides to pnpm workspace instead of package.json


Closes ACQ-6385

## Checklist:

- [ ] I've added/updated tests to cover my changes
- [ ] I've created an issue associated with this PR