### PR TITLE
chore(release): v2.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ EXAMPLE
   $ spot checksum api.ts
 ```
 
-_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v2.0.2/build/cli/src/commands/checksum.js)_
+_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/checksum.js)_
 
 ## `spot docs SPOT_CONTRACT`
 
@@ -195,7 +195,7 @@ EXAMPLE
   $ spot docs api.ts
 ```
 
-_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v2.0.2/build/cli/src/commands/docs.js)_
+_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/docs.js)_
 
 ## `spot generate`
 
@@ -216,7 +216,7 @@ EXAMPLE
   $ spot generate --contract api.ts --language yaml --generator openapi3 --out output/
 ```
 
-_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v2.0.2/build/cli/src/commands/generate.js)_
+_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/generate.js)_
 
 ## `spot help [COMMAND]`
 
@@ -254,7 +254,7 @@ EXAMPLE
   - package.json
 ```
 
-_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v2.0.2/build/cli/src/commands/init.js)_
+_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/init.js)_
 
 ## `spot lint SPOT_CONTRACT`
 
@@ -285,7 +285,7 @@ EXAMPLES
   $ spot lint --no-nullable-arrays=off
 ```
 
-_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v2.0.2/build/cli/src/commands/lint.js)_
+_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/lint.js)_
 
 ## `spot mock SPOT_CONTRACT`
 
@@ -316,7 +316,7 @@ EXAMPLE
   $ spot mock api.ts
 ```
 
-_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v2.0.2/build/cli/src/commands/mock.js)_
+_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/mock.js)_
 
 ## `spot validate SPOT_CONTRACT`
 
@@ -336,7 +336,7 @@ EXAMPLE
   $ spot validate api.ts
 ```
 
-_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v2.0.2/build/cli/src/commands/validate.js)_
+_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/validate.js)_
 
 ## `spot validation-server SPOT_CONTRACT`
 
@@ -357,7 +357,7 @@ EXAMPLE
   $ spot validation-server api.ts
 ```
 
-_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v2.0.2/build/cli/src/commands/validation-server.js)_
+_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/validation-server.js)_
 <!-- commandsstop -->
 
 # Releases

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airtasker/spot",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "author": "Francois Wouts, Leslie Fung",
   "bin": {
     "spot": "./bin/run"


### PR DESCRIPTION
## Release v2.0.3

### Changes

- **fix(RVNGR-1577)**: `unionTypeToDiscriminatorObject` now emits discriminator mapping entries for **all** concrete leaf types when a union member is itself a union. Previously, only the first leaf was emitted (`.find()` bug), causing downstream codegen (iOS Swift, Android Kotlin) to drop discriminator values and crash at runtime.

  Reproducer: `BrowseTasksFeedListFilterType` with `AdsSlider = AdsSliderSingle | AdsSliderDouble` — `ads_slider_double` was silently absent from the generated `api.yml` mapping.

### Version bump

`2.0.2` → `2.0.3` (patch — bug fix, no breaking changes, no new API surface)

### Post-merge steps

1. Create a GitHub release tagged `v2.0.3` to trigger NPM publish via CircleCI
2. Bump `@airtasker/spot` in `bff-client` and re-run `pnpm generate:yaml` to pick up the fixed discriminator mapping
3. Trigger iOS and Android codegen to consume the corrected `api.yml`