### PR TITLE
ci: pin test-summary/action to v2.4

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,7 +55,7 @@ jobs:
       contents: read
     steps:
       - name: Test summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@v2.4
         with:
           paths: ./test-reports/**/*.xml
 


### PR DESCRIPTION
## Summary

`test-summary/action@v2` is currently broken — the `v2` tag was re-pointed to an unbuilt commit (`001f872`) that contains only source files and is missing the compiled `index.js` the runner needs.

`v2.4` is the latest tag with the compiled artifact and works correctly.

See upstream issue: https://github.com/test-summary/action/issues/75