### PR TITLE
ci: use github-hosted runners for public repo security

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     name: test-node-${{ matrix.node-version }}
-    runs-on: runs-on,runner=4cpu-linux-x64
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
@@ -49,7 +49,7 @@ jobs:
           path: ./test-reports
 
   test-summary-publish:
-    runs-on: runs-on,runner=4cpu-linux-x64
+    runs-on: ubuntu-latest
     needs: [test]
     permissions:
       contents: read
@@ -60,7 +60,7 @@ jobs:
           paths: ./test-reports/**/*.xml
 
   lint-check:
-    runs-on: runs-on,runner=4cpu-linux-x64
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -71,7 +71,7 @@ jobs:
         run: pnpm lint:check
 
   publish:
-    runs-on: runs-on,runner=4cpu-linux-x64
+    runs-on: ubuntu-latest
     if: github.event_name == 'release'
     needs:
       - test


### PR DESCRIPTION

Jira: [APE-2041](https://airtasker.atlassian.net/browse/APE-2041)

---

## Summary

Switches all jobs in `.github/workflows/build-and-test.yml` from runs-on.com (`4cpu-linux-x64`) to GitHub-hosted `ubuntu-latest`.

This repo is public, so workflows can be triggered by PRs from untrusted contributors. Executing PR-author code on managed/self-hosted runner infrastructure exposes that infrastructure — secrets, network position, cached credentials, neighbouring jobs — to whoever opened the PR. GitHub-hosted runners are ephemeral, network-isolated, and discarded after each job, which is the correct execution environment for untrusted code.

The capacity drop is minimal: `ubuntu-latest` provides 4 vCPU for public repos, matching the previous `4cpu-linux-x64` configuration.

This change is consistent with the org policy update in `ai-global-context` (`deployment.md` → "Exception: public repositories must use GitHub-hosted runners").

## Test plan

- [ ] CI runs green on this PR
- [ ] Matrix test job (`test-node-{18,20,22,24}` × `shard-{1..4}`) completes within reasonable time
- [ ] `test-summary-publish`, `lint-check` jobs succeed
- [ ] No regressions in `publish` job (release-only — won't run on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APE-2041]: https://airtasker.atlassian.net/browse/APE-2041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ