### PR TITLE
fix(COMPASS-17): declare the oclif packages bin/run needs at runtime

### DIFF
--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -19,16 +19,35 @@ runs:
     run: pnpm build
     shell: bash
 
-  - name: Smoke-test the built CLI
+  - name: Smoke-test the built CLI against a production-only install
     # Every jest suite imports the library directly, so none of them loads
-    # bin/run. A runtime dependency that resolves only because a package
-    # manager hoisted it therefore passes the whole suite and then kills every
-    # command on the first real invocation — which is what pnpm's isolated
-    # layout, and the docker image built from it, actually do.
+    # bin/run: a package the entrypoint needs can be missing from
+    # `dependencies` and the whole suite still passes.
+    #
+    # The install has to be `--prod` for this step to observe that. Under
+    # pnpm's isolated layout both dependency sets are symlinked into
+    # node_modules, so invoking the CLI after a full install shows only that a
+    # package is declared *somewhere* — which is true of a devDependency, and
+    # is exactly the case that breaks. Pruning first is what makes the step
+    # fail on a misdeclared runtime dependency.
+    #
+    # Restores the full install afterwards, because the jest step below needs
+    # it. `build/` predates the prune and is unaffected by both installs.
+    #
+    # Once per Node version: the failure depends on the dependency set and the
+    # runtime, not on which test shard this job happens to be running.
+    if: inputs.shard == '1'
+    env:
+      # `--prod` removes the modules directory to prune the dev tree, and
+      # refuses to do that unattended unless CI is set. Actions sets it
+      # already; naming it here keeps the step from depending on that.
+      CI: "true"
     run: |-
       set -uex
+      pnpm install --frozen-lockfile --prod
       node bin/run --help
       node bin/run validate test-fixtures/contract/api.ts
+      pnpm install --frozen-lockfile
     shell: bash
 
   - name: Create test reports directory

--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -19,6 +19,18 @@ runs:
     run: pnpm build
     shell: bash
 
+  - name: Smoke-test the built CLI
+    # Every jest suite imports the library directly, so none of them loads
+    # bin/run. A runtime dependency that resolves only because a package
+    # manager hoisted it therefore passes the whole suite and then kills every
+    # command on the first real invocation — which is what pnpm's isolated
+    # layout, and the docker image built from it, actually do.
+    run: |-
+      set -uex
+      node bin/run --help
+      node bin/run validate test-fixtures/contract/api.ts
+    shell: bash
+
   - name: Create test reports directory
     run: mkdir -p ./test-reports/jest
     shell: bash

--- a/.github/actions/build-and-test/action.yml
+++ b/.github/actions/build-and-test/action.yml
@@ -24,27 +24,21 @@ runs:
     # bin/run: a package the entrypoint needs can be missing from
     # `dependencies` and the whole suite still passes.
     #
-    # The install has to be `--prod` for this step to observe that. Under
-    # pnpm's isolated layout both dependency sets are symlinked into
-    # node_modules, so invoking the CLI after a full install shows only that a
-    # package is declared *somewhere* — which is true of a devDependency, and
-    # is exactly the case that breaks. Pruning first is what makes the step
-    # fail on a misdeclared runtime dependency.
-    #
-    # Restores the full install afterwards, because the jest step below needs
-    # it. `build/` predates the prune and is unaffected by both installs.
-    #
-    # Once per Node version: the failure depends on the dependency set and the
-    # runtime, not on which test shard this job happens to be running.
+    # The install has to be `--prod` for this step to observe that. Under pnpm's
+    # isolated layout both dependency sets are symlinked into node_modules, so
+    # invoking the CLI after a full install shows only that a package is
+    # declared somewhere — true of a devDependency, and exactly the case that
+    # breaks. Pruning first is what makes the step fail on a misdeclared runtime
+    # dependency, so the prune is asserted rather than assumed.
     if: inputs.shard == '1'
     env:
-      # `--prod` removes the modules directory to prune the dev tree, and
-      # refuses to do that unattended unless CI is set. Actions sets it
-      # already; naming it here keeps the step from depending on that.
+      # `--prod` removes the modules directory, and refuses to do that
+      # unattended without this. Actions sets it; not depending on that.
       CI: "true"
     run: |-
       set -uex
       pnpm install --frozen-lockfile --prod
+      test ! -e node_modules/jest
       node bin/run --help
       node bin/run validate test-fixtures/contract/api.ts
       pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
+    "@oclif/errors": "^1.3.6",
+    "@oclif/help": "^1.0.15",
     "@oclif/plugin-help": "^3.2.3",
     "ajv": "^8.18.0",
     "ajv-formats": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,12 @@ importers:
       '@oclif/config':
         specifier: ^1.17.0
         version: 1.18.17
+      '@oclif/errors':
+        specifier: ^1.3.6
+        version: 1.3.6
+      '@oclif/help':
+        specifier: ^1.0.15
+        version: 1.0.15
       '@oclif/plugin-help':
         specifier: ^3.2.3
         version: 3.3.1


### PR DESCRIPTION
## Ticket

[COMPASS-17](https://airtasker.atlassian.net/browse/COMPASS-17) — Change `spot` to be interacted with as a docker image rather than as a NodeJS tool

> **Stacked on #2709 → #2708.** Review those first. `build-and-test` does report on this PR — `test-node-{18,20,22,24}` and `lint-check` are green, so the new smoke-test step has run on all four Node versions.

## What

Declare `@oclif/errors` and `@oclif/help` as dependencies, and smoke-test the built CLI in CI.

## Why

**`spot`'s CLI cannot start under pnpm's default `node_modules` layout.** `bin/run` requires `@oclif/errors/handle`, and `@oclif/command` reaches for `@oclif/help` when it renders help or an error. Neither is declared in `package.json`; both have only ever resolved because a package manager hoisted them out of `@oclif/command`'s own tree.

```
$ node bin/run validate api.ts
Error: Cannot find module '@oclif/errors/handle'
```

That is on `master` today, in a clean `pnpm install --frozen-lockfile` checkout, before any change in this stack.

npm consumers are fine — npm's flat layout has been covering for the missing declarations, which is why nobody has hit it. It matters now because the docker image later in this ticket installs with `pnpm install --frozen-lockfile --prod`. Without this, the image would build green and then fail on every single invocation.

## The gap this exposes

The whole jest suite — 529 tests — passes against a CLI that cannot start. Every suite imports the library directly (`lib/src/...`); nothing loads `bin/run`, so nothing exercises the oclif entrypoint or the package's own dependency closure. Green CI was never evidence the binary worked.

Nor is a unit test the right guard: `@oclif/errors` is required by `bin/run` itself, but `@oclif/help` is pulled in by `@oclif/command` at render time, so a test that inspects `bin/run`'s `require()` calls catches one and misses the other. The guard has to invoke the binary.

So the fix ships with a CI step in `.github/actions/build-and-test/action.yml`, right after the existing `pnpm build`:

```yaml
pnpm install --frozen-lockfile --prod                   # prune the dev tree first
node bin/run --help                                    # exercises the @oclif/help path
node bin/run validate test-fixtures/contract/api.ts     # exercises a real command end to end
pnpm install --frozen-lockfile                          # restore for the jest step
```

**The install has to be `--prod`.** Under pnpm's isolated layout both dependency sets are symlinked into `node_modules`, so invoking the CLI after a full install shows only that a package is declared *somewhere* — which is true of a devDependency, and is exactly the case that breaks. Moving these two back to `devDependencies` leaves a full-install smoke test green while `--prod` dies with `MODULE_NOT_FOUND` on every invocation. Pruning first is what makes the step fail on a misdeclared runtime dependency.

`CI` is set explicitly on the step: `--prod` removes the modules directory to prune, and refuses to do that unattended without it. Actions sets it already, but the step should not depend on that.

It runs once per Node version rather than once per shard — the failure depends on the dependency set and the runtime, not on which quarter of the suite is running, and the prune is a full reinstall. Fails loudly via `set -uex`.

## How this was verified

- **Before:** on this branch's base, a clean install then `node bin/run --help` and `node bin/run validate …` both die with `Cannot find module '@oclif/errors/handle'`. So the failure is pre-existing, not introduced by anything in this stack.
- **The guard discriminates.** Under `--prod`: `jest` is pruned, both oclif packages remain, and `--help` and `validate` succeed. With their root links removed, the entrypoint dies with `MODULE_NOT_FOUND`.
- **After:** every command the docker image is planned to expose was run against a real contract:

  | Command | Result |
  |---|---|
  | `--help` | prints the full command table |
  | `validate` | `Contract is valid` |
  | `lint` | `Found 0 errors and 0 warnings` |
  | `checksum` | `ef62006f8d00d5899d7f0f03f3c1ca66d2b52be4` |
  | `generate -g openapi3 -l yaml -o …` | writes `api.yml` |
  | `validation-server … -p 5677` | see below |

- **`validation-server` specifically**, because two of the image's interface promises depend on it: with stdout redirected to a file — so **no TTY** — it printed `Validation server running on port 5677`, and `GET /health` answered `200`. That is the string bff-client's Gradle `ExecFork` `waitForOutput` waits on, and the check that it is line-buffered without a terminal.
- `pnpm lint:check` clean.

## Scope note

This was found while building `ts-lint` (next PR in the stack), which could not be exercised through the CLI at all until it was fixed. It is a separate concern from `ts-lint`, so it is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[COMPASS-17]: https://airtasker.atlassian.net/browse/COMPASS-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
