### PR TITLE
feat(COMPASS-17): add ts-lint command with bundled canonical config

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,5 @@
 build/
+
+# Held to the canonical contract formatting that ts-lint bundles, which is not
+# this repo's own; dirty/ is deliberately unformatted.
+test-fixtures/ts-lint/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Spot is a TypeScript-based API contract definition tool that generates OpenAPI, 
 ### CLI Usage (after build)
 - `npx @airtasker/spot generate --contract api.ts --generator openapi3 --out output/` - Generate OpenAPI3 from contract
 - `npx @airtasker/spot lint api.ts` - Lint a Spot contract
+- `npx @airtasker/spot ts-lint spots` - Check the TypeScript in a contract tree for formatting, lint and type errors, under configuration Spot bundles itself (`--fix` rewrites in place)
 - `npx @airtasker/spot mock api.ts` - Run mock server from contract
 - `npx @airtasker/spot validate api.ts` - Validate contract syntax
 

--- a/cli/src/commands/ts-lint.spec.ts
+++ b/cli/src/commands/ts-lint.spec.ts
@@ -30,8 +30,10 @@ describe("ts-lint command", () => {
   });
 
   afterEach(() => {
-    writeSpy.mockRestore();
+    // Restored first: a throw from mockRestore would otherwise leak a non-zero
+    // exit code, which reports as a wholly green suite that exits 1.
     process.exitCode = restoreExitCode;
+    writeSpy.mockRestore();
   });
 
   test("exits zero and says so on a clean tree", async () => {
@@ -53,9 +55,6 @@ describe("ts-lint command", () => {
   });
 
   test("exits one when the directory holds no contracts", async () => {
-    // A tree that has been renamed or arrived empty reaches this path. If it
-    // exited zero the gate would pass while checking nothing, which is the one
-    // failure a consumer's green pipeline could never show them.
     const empty = fs.mkdtempSync(path.join(os.tmpdir(), "spot-ts-lint-empty-"));
 
     await TsLint.run([empty]);

--- a/cli/src/commands/ts-lint.spec.ts
+++ b/cli/src/commands/ts-lint.spec.ts
@@ -1,0 +1,66 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import TsLint from "./ts-lint";
+
+const FIXTURES = path.join(__dirname, "../../../test-fixtures/ts-lint");
+
+/**
+ * The exit code is the whole of this command's contract with CI: a consumer's
+ * pipeline reads nothing else. It is also the part a unit test on `tsLint`
+ * cannot reach, because the mapping from an outcome to an exit lives here.
+ */
+describe("ts-lint command", () => {
+  jest.setTimeout(60000);
+
+  let restoreExitCode: number | undefined;
+  let out: string;
+  let writeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    restoreExitCode = process.exitCode;
+    process.exitCode = undefined;
+    out = "";
+    writeSpy = jest
+      .spyOn(process.stdout, "write")
+      .mockImplementation((chunk: unknown) => {
+        out += String(chunk);
+        return true;
+      });
+  });
+
+  afterEach(() => {
+    writeSpy.mockRestore();
+    process.exitCode = restoreExitCode;
+  });
+
+  test("exits zero and says so on a clean tree", async () => {
+    await TsLint.run([path.join(FIXTURES, "clean")]);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(out).toContain("No problems found");
+  });
+
+  test("exits one on a tree with problems, reporting every category", async () => {
+    await TsLint.run([path.join(FIXTURES, "dirty")]);
+
+    expect(process.exitCode).toBe(1);
+    expect(out).toContain("Formatting (");
+    expect(out).toContain("Lint (");
+    expect(out).toContain("Types (");
+    // A run that found something must not also claim the tree is clean.
+    expect(out).not.toContain("No problems found");
+  });
+
+  test("exits one when the directory holds no contracts", async () => {
+    // A tree that has been renamed or arrived empty reaches this path. If it
+    // exited zero the gate would pass while checking nothing, which is the one
+    // failure a consumer's green pipeline could never show them.
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "spot-ts-lint-empty-"));
+
+    await TsLint.run([empty]);
+
+    expect(process.exitCode).toBe(1);
+    expect(out).toContain("Nothing was checked");
+  });
+});

--- a/cli/src/commands/ts-lint.ts
+++ b/cli/src/commands/ts-lint.ts
@@ -41,10 +41,19 @@ export default class TsLint extends Command {
     fixed.forEach(file => this.log(`Fixed ${file}`));
     report.forEach(line => this.log(line));
 
-    if (ok) {
+    // Only claim the tree is clean when there is nothing to show. A report can
+    // be non-empty on a passing run — warnings do not fail the command — and
+    // printing both the findings and "No problems found" contradicts itself.
+    if (ok && report.length === 0) {
       this.log("No problems found");
-    } else {
-      process.exit(1);
+    }
+
+    if (!ok) {
+      // Not process.exit: this.log writes to stdout, which is asynchronous
+      // when stdout is a pipe — every CI runner — and exiting outright
+      // truncates the report mid-stream. Setting the code lets Node flush and
+      // exit on its own.
+      process.exitCode = 1;
     }
   }
 }

--- a/cli/src/commands/ts-lint.ts
+++ b/cli/src/commands/ts-lint.ts
@@ -1,0 +1,50 @@
+import { Command, flags } from "@oclif/command";
+import { tsLint } from "../../../lib/src/ts-lint/ts-lint";
+
+const ARG_DIR = "directory";
+
+/**
+ * oclif command to check a tree of Spot contracts for formatting, lint and
+ * type errors, under configuration bundled with Spot itself.
+ */
+export default class TsLint extends Command {
+  static description =
+    "Check the TypeScript in a Spot contract tree for formatting, lint and type errors";
+
+  static examples = ["$ spot ts-lint", "$ spot ts-lint spots --fix"];
+
+  static args = [
+    {
+      name: ARG_DIR,
+      required: false,
+      default: ".",
+      description: "directory to check",
+      hidden: false
+    }
+  ];
+
+  static flags: flags.Input<flags.Output> = {
+    help: flags.help({ char: "h" }),
+    fix: flags.boolean({
+      description: "Reformat and apply lint fixes in place",
+      default: false
+    })
+  };
+
+  async run(): Promise<void> {
+    const { args, flags } = this.parse(TsLint);
+
+    const { report, fixed, ok } = await tsLint(args[ARG_DIR], {
+      fix: flags.fix
+    });
+
+    fixed.forEach(file => this.log(`Fixed ${file}`));
+    report.forEach(line => this.log(line));
+
+    if (ok) {
+      this.log("No problems found");
+    } else {
+      process.exit(1);
+    }
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,10 @@ module.exports = tseslint.config(
       "**/build/",
       "docs/webpack.config.js",
       "jest.config.js",
-      "jest.ci.config.js"
+      "jest.ci.config.js",
+      // Held to the canonical contract config that `ts-lint` bundles, which
+      // differs from this repo's own. `dirty/` is deliberately broken.
+      "test-fixtures/ts-lint/"
     ]
   },
   {

--- a/lib/src/generators/openapi2/openapi2-specification.ts
+++ b/lib/src/generators/openapi2/openapi2-specification.ts
@@ -101,24 +101,19 @@ export type HeaderObject =
   | ArrayHeaderObject;
 
 export interface StringHeaderObject
-  extends HeaderObjectBase,
-    StringParameterObject {}
+  extends HeaderObjectBase, StringParameterObject {}
 
 export interface NumberHeaderObject
-  extends HeaderObjectBase,
-    NumberParameterObjectType {}
+  extends HeaderObjectBase, NumberParameterObjectType {}
 
 export interface IntegerHeaderObject
-  extends HeaderObjectBase,
-    IntegerParameterObjectType {}
+  extends HeaderObjectBase, IntegerParameterObjectType {}
 
 export interface BooleanHeaderObject
-  extends HeaderObjectBase,
-    BooleanParameterObjectType {}
+  extends HeaderObjectBase, BooleanParameterObjectType {}
 
 export interface ArrayHeaderObject
-  extends HeaderObjectBase,
-    ArrayParameterObjectType {}
+  extends HeaderObjectBase, ArrayParameterObjectType {}
 
 interface HeaderObjectBase {
   description?: string;
@@ -172,16 +167,13 @@ interface ParameterObjectBase {
 }
 
 type QueryParameterObjectType =
-  | BaseParameterObjectTypes
-  | ArrayMultiParameterObjectType;
+  BaseParameterObjectTypes | ArrayMultiParameterObjectType;
 
 type HeaderParameterObjectType =
-  | BaseParameterObjectTypes
-  | ArrayParameterObjectType;
+  BaseParameterObjectTypes | ArrayParameterObjectType;
 
 type PathParameterObjectType =
-  | BaseParameterObjectTypes
-  | ArrayParameterObjectType;
+  BaseParameterObjectTypes | ArrayParameterObjectType;
 
 type FormDataParameterObjectType =
   | BaseParameterObjectTypes
@@ -204,15 +196,13 @@ export interface StringParameterObject {
   enum?: string[];
 }
 
-export interface NumberParameterObjectType
-  extends NumberParameterObjectTypeBase {
+export interface NumberParameterObjectType extends NumberParameterObjectTypeBase {
   type: "number";
   format?: "float" | "double";
   default?: number;
 }
 
-export interface IntegerParameterObjectType
-  extends NumberParameterObjectTypeBase {
+export interface IntegerParameterObjectType extends NumberParameterObjectTypeBase {
   type: "integer";
   format?: "int32" | "int64";
   default?: number;
@@ -232,8 +222,7 @@ export interface ArrayParameterObjectType extends ArrayParameterObjectTypeBase {
   collectionFormat?: "csv" | "ssv" | "tsv" | "pipes";
 }
 
-export interface ArrayMultiParameterObjectType
-  extends ArrayParameterObjectTypeBase {
+export interface ArrayMultiParameterObjectType extends ArrayParameterObjectTypeBase {
   collectionFormat?: "csv" | "ssv" | "tsv" | "pipes" | "multi";
 }
 
@@ -306,29 +295,25 @@ export type OAuth2SecuritySchemeObject =
   | AccessCodeOAuth2SecuritySchemeObject;
 
 export interface ImplicitOAuth2SecuritySchemeObject
-  extends OAuth2SecuritySchemeObjectBase,
-    SecuritySchemeObjectBase {
+  extends OAuth2SecuritySchemeObjectBase, SecuritySchemeObjectBase {
   flow: "implicit";
   authorizationUrl: string;
 }
 
 export interface PasswordOAuth2SecuritySchemeObject
-  extends OAuth2SecuritySchemeObjectBase,
-    SecuritySchemeObjectBase {
+  extends OAuth2SecuritySchemeObjectBase, SecuritySchemeObjectBase {
   flow: "password";
   tokenUrl: string;
 }
 
 export interface ApplicationOAuth2SecuritySchemeObject
-  extends OAuth2SecuritySchemeObjectBase,
-    SecuritySchemeObjectBase {
+  extends OAuth2SecuritySchemeObjectBase, SecuritySchemeObjectBase {
   flow: "application";
   tokenUrl: string;
 }
 
 export interface AccessCodeOAuth2SecuritySchemeObject
-  extends OAuth2SecuritySchemeObjectBase,
-    SecuritySchemeObjectBase {
+  extends OAuth2SecuritySchemeObjectBase, SecuritySchemeObjectBase {
   flow: "accessCode";
   authorizationUrl: string;
   tokenUrl: string;
@@ -398,15 +383,13 @@ interface SchemaObjectBase {
 }
 
 export interface NumberSchemaObject
-  extends SchemaObjectBase,
-    NumberSchemaObjectBase {
+  extends SchemaObjectBase, NumberSchemaObjectBase {
   type: "number";
   format?: "float" | "double";
 }
 
 export interface IntegerSchemaObject
-  extends SchemaObjectBase,
-    NumberSchemaObjectBase {
+  extends SchemaObjectBase, NumberSchemaObjectBase {
   type: "integer";
   format?: "int32" | "int64";
 }

--- a/lib/src/generators/openapi3/openapi3-specification.ts
+++ b/lib/src/generators/openapi3/openapi3-specification.ts
@@ -158,15 +158,13 @@ interface SchemaObjectBase {
 }
 
 export interface NumberSchemaObject
-  extends SchemaObjectBase,
-    NumberSchemaObjectBase {
+  extends SchemaObjectBase, NumberSchemaObjectBase {
   type: "number";
   format?: "float" | "double";
 }
 
 export interface IntegerSchemaObject
-  extends SchemaObjectBase,
-    NumberSchemaObjectBase {
+  extends SchemaObjectBase, NumberSchemaObjectBase {
   type: "integer";
   format?: "int32" | "int64";
 }
@@ -222,8 +220,7 @@ export interface ObjectSchemaObject extends SchemaObjectBase {
 
 export interface ObjectPropertiesSchemaObject {
   [name: string]:
-    | (SchemaObject & ObjectPropertySchemaObjectBase)
-    | ReferenceObject;
+    (SchemaObject & ObjectPropertySchemaObjectBase) | ReferenceObject;
 }
 
 interface ObjectPropertySchemaObjectBase {
@@ -285,8 +282,7 @@ export interface OAuth2SecuritySchemeObject extends SecuritySchemeObjectBase {
   flows: OAuthFlowsObject;
 }
 
-export interface OpenIdConnectSecuritySchemeObject
-  extends SecuritySchemeObjectBase {
+export interface OpenIdConnectSecuritySchemeObject extends SecuritySchemeObjectBase {
   type: "openIdConnect";
   openIdConnectUrl: string;
 }

--- a/lib/src/parsers/__spec-examples__/types.ts
+++ b/lib/src/parsers/__spec-examples__/types.ts
@@ -42,9 +42,7 @@ interface TypeInterface {
   union: boolean | Date | null;
   unionDiscriminated: DiscriminatedUnionElementA | DiscriminatedUnionElementB;
   unionDiscriminatedNullable:
-    | DiscriminatedUnionElementA
-    | DiscriminatedUnionElementB
-    | null;
+    DiscriminatedUnionElementA | DiscriminatedUnionElementB | null;
   aliasString: AliasString;
   aliasArray: AliasArray;
   aliasWithDescription: AliasWithDescription;

--- a/lib/src/ts-lint/eslint-config.ts
+++ b/lib/src/ts-lint/eslint-config.ts
@@ -1,0 +1,46 @@
+import js from "@eslint/js";
+import { Linter } from "eslint";
+import prettierConfig from "eslint-config-prettier/flat";
+import tseslint from "typescript-eslint";
+
+/**
+ * The lint rules Spot contracts are held to.
+ *
+ * This is a value, not a config file path. `ts-lint` hands it to ESLint with
+ * `overrideConfigFile: true`, so the plugins are the ones this module
+ * imported — resolved from Spot's own `node_modules` — and an
+ * `eslint.config.*` sitting next to a contract is neither read nor needed.
+ *
+ * Contract syntax is why most of the rules below are off: an endpoint is a
+ * class nobody references, holding decorated methods with empty bodies, whose
+ * parameters exist to be read by the parser rather than by the code.
+ */
+export const eslintConfig: Linter.Config[] = tseslint.config(
+  js.configs.recommended,
+  tseslint.configs.recommended,
+  // Formatting is the Prettier step's job. Without this, a rule that also has
+  // an opinion about layout reports a second, differently-worded complaint
+  // about a line Prettier has already flagged.
+  prettierConfig,
+  {
+    rules: {
+      "@typescript-eslint/naming-convention": [
+        "error",
+        { selector: "default", format: ["camelCase", "PascalCase"] },
+        // Header and query-parameter names are wire names — `x-auth-token`,
+        // `sample-query` — and are not the contract author's to choose.
+        { selector: "property", format: null }
+      ],
+      "@typescript-eslint/no-inferrable-types": "off",
+      "@typescript-eslint/no-use-before-define": "off",
+      "@typescript-eslint/no-empty-function": "off",
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+      "@typescript-eslint/no-empty-object-type": "off",
+      // `String`, `Number` and `Boolean` are Spot's own contract types, not the
+      // JavaScript wrapper objects these rules exist to catch.
+      "@typescript-eslint/no-wrapper-object-types": "off",
+      "@typescript-eslint/no-unsafe-function-type": "off"
+    }
+  }
+) as Linter.Config[];

--- a/lib/src/ts-lint/eslint-config.ts
+++ b/lib/src/ts-lint/eslint-config.ts
@@ -37,8 +37,13 @@ export const eslintConfig: Linter.Config[] = tseslint.config(
       "@typescript-eslint/explicit-function-return-type": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/no-empty-object-type": "off",
-      // `String`, `Number` and `Boolean` are Spot's own contract types, not the
-      // JavaScript wrapper objects these rules exist to catch.
+      // A contract imports `String`, `Number` and `Boolean` from
+      // `@airtasker/spot`, and that import shadows the global — so on a
+      // well-formed contract this rule has nothing to say either way. What
+      // turning it off suppresses is the opposite case: a file that names the
+      // global because the import is missing. That is a real mistake, and it is
+      // caught where it has consequences, by the parser rejecting the type,
+      // rather than as a wrapper-object complaint here.
       "@typescript-eslint/no-wrapper-object-types": "off",
       "@typescript-eslint/no-unsafe-function-type": "off"
     }

--- a/lib/src/ts-lint/prettier-config.ts
+++ b/lib/src/ts-lint/prettier-config.ts
@@ -1,0 +1,22 @@
+import { Options } from "prettier";
+import * as estreePlugin from "prettier/plugins/estree";
+import * as typescriptPlugin from "prettier/plugins/typescript";
+
+/**
+ * The formatting Spot contracts are held to.
+ *
+ * Passed to Prettier explicitly on every call, alongside `prettier/standalone`
+ * rather than the default entry point. Neither Prettier's config discovery nor
+ * its plugin resolution is used, so a `.prettierrc` left behind next to a
+ * contract cannot change how that contract is formatted, and the TypeScript
+ * parser is the one this package installed.
+ */
+export const prettierConfig: Options = {
+  parser: "typescript",
+  plugins: [estreePlugin, typescriptPlugin],
+  trailingComma: "none",
+  tabWidth: 2,
+  semi: true,
+  singleQuote: true,
+  printWidth: 80
+};

--- a/lib/src/ts-lint/ts-lint.spec.ts
+++ b/lib/src/ts-lint/ts-lint.spec.ts
@@ -73,12 +73,73 @@ describe("tsLint", () => {
     );
     fs.writeFileSync(
       path.join(dir, "eslint.config.mjs"),
-      "export default [{ rules: { 'no-undef': 'error' } }];\n"
+      // A rule the bundled config never mentions, on a construct the fixture
+      // has four of. `no-undef` would not do: the bundled config's TypeScript
+      // preset switches it off again, so a leftover config that *was* read
+      // would still report nothing and this test would pass either way.
+      "export default [{ rules: { 'no-restricted-syntax': ['error', " +
+        "{ selector: 'TSInterfaceDeclaration', message: 'leftover config was read' }] } }];\n"
     );
 
     const outcome = await tsLint(dir, { fix: false });
 
     expect(outcome.report).toEqual([]);
+    expect(outcome.ok).toBe(true);
+  });
+
+  test("fails a directory that holds no contracts", async () => {
+    // Distinct from a directory that does not exist, which fails from readdir.
+    // A tree that has been renamed, arrived empty in a bind mount, or been
+    // partially checked out looks like this, and calling it a pass turns the
+    // gate into a no-op that a green pipeline cannot reveal.
+    const empty = fs.mkdtempSync(path.join(os.tmpdir(), "spot-ts-lint-empty-"));
+
+    const outcome = await tsLint(empty, { fix: false });
+
+    expect(outcome.ok).toBe(false);
+    expect(outcome.report.join("\n")).toContain("Nothing was checked");
+  });
+
+  test("a file Prettier cannot parse does not discard the other findings", async () => {
+    const dir = copyFixture("dirty");
+    fs.writeFileSync(path.join(dir, "zz-broken.ts"), "export const = ;\n");
+
+    const outcome = await tsLint(dir, { fix: false });
+    const report = outcome.report.join("\n");
+
+    // The unparseable file is named, rather than surfacing as a bare parse
+    // error with a line number and no path.
+    expect(report).toContain("zz-broken.ts");
+    // And the steps that had already run still report.
+    expect(report).toContain(NAMING_ERROR);
+    expect(report).toContain(TYPE_ERROR);
+    expect(outcome.ok).toBe(false);
+  });
+
+  test("does not report type errors from inside node_modules", async () => {
+    const dir = copyFixture("clean");
+    // Resolving the tree's imports reaches into node_modules, and a declaration
+    // file there can carry its own errors. A contract author cannot edit them
+    // and --fix cannot reach them, so reporting them would be a standing
+    // failure with no move against it.
+    const pkg = path.join(dir, "node_modules", "junk");
+    fs.mkdirSync(pkg, { recursive: true });
+    fs.writeFileSync(
+      path.join(pkg, "package.json"),
+      JSON.stringify({ name: "junk", version: "1.0.0", types: "index.d.ts" })
+    );
+    fs.writeFileSync(
+      path.join(pkg, "index.d.ts"),
+      "export declare const bad: number;\nexport declare const worse: number = 'no';\n"
+    );
+    fs.writeFileSync(
+      path.join(dir, "uses-junk.ts"),
+      "import { bad } from 'junk';\n\nexport const value = bad;\n"
+    );
+
+    const outcome = await tsLint(dir, { fix: false });
+
+    expect(outcome.report.join("\n")).not.toContain("node_modules");
     expect(outcome.ok).toBe(true);
   });
 

--- a/lib/src/ts-lint/ts-lint.spec.ts
+++ b/lib/src/ts-lint/ts-lint.spec.ts
@@ -74,9 +74,9 @@ describe("tsLint", () => {
     fs.writeFileSync(
       path.join(dir, "eslint.config.mjs"),
       // A rule the bundled config never mentions, on a construct the fixture
-      // has four of. `no-undef` would not do: the bundled config's TypeScript
+      // contains. `no-undef` would not do: the bundled config's TypeScript
       // preset switches it off again, so a leftover config that *was* read
-      // would still report nothing and this test would pass either way.
+      // would report nothing either way.
       "export default [{ rules: { 'no-restricted-syntax': ['error', " +
         "{ selector: 'TSInterfaceDeclaration', message: 'leftover config was read' }] } }];\n"
     );
@@ -88,10 +88,6 @@ describe("tsLint", () => {
   });
 
   test("fails a directory that holds no contracts", async () => {
-    // Distinct from a directory that does not exist, which fails from readdir.
-    // A tree that has been renamed, arrived empty in a bind mount, or been
-    // partially checked out looks like this, and calling it a pass turns the
-    // gate into a no-op that a green pipeline cannot reveal.
     const empty = fs.mkdtempSync(path.join(os.tmpdir(), "spot-ts-lint-empty-"));
 
     const outcome = await tsLint(empty, { fix: false });
@@ -102,14 +98,16 @@ describe("tsLint", () => {
 
   test("a file Prettier cannot parse does not discard the other findings", async () => {
     const dir = copyFixture("dirty");
-    fs.writeFileSync(path.join(dir, "zz-broken.ts"), "export const = ;\n");
+    fs.writeFileSync(path.join(dir, "aa-broken.ts"), "export const = ;\n");
 
     const outcome = await tsLint(dir, { fix: false });
     const report = outcome.report.join("\n");
 
     // The unparseable file is named, rather than surfacing as a bare parse
     // error with a line number and no path.
-    expect(report).toContain("zz-broken.ts");
+    expect(report).toContain("aa-broken.ts");
+    // Sorts first, so this also pins that the walk continues past it.
+    expect(report).toContain("Formatting (2):");
     // And the steps that had already run still report.
     expect(report).toContain(NAMING_ERROR);
     expect(report).toContain(TYPE_ERROR);
@@ -118,10 +116,8 @@ describe("tsLint", () => {
 
   test("does not report type errors from inside node_modules", async () => {
     const dir = copyFixture("clean");
-    // Resolving the tree's imports reaches into node_modules, and a declaration
-    // file there can carry its own errors. A contract author cannot edit them
-    // and --fix cannot reach them, so reporting them would be a standing
-    // failure with no move against it.
+    // Held by `skipLibCheck` in the shared contract compiler options, so `parse`
+    // agrees rather than throwing on diagnostics this step drops.
     const pkg = path.join(dir, "node_modules", "junk");
     fs.mkdirSync(pkg, { recursive: true });
     fs.writeFileSync(

--- a/lib/src/ts-lint/ts-lint.spec.ts
+++ b/lib/src/ts-lint/ts-lint.spec.ts
@@ -1,0 +1,97 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { tsLint } from "./ts-lint";
+
+const FIXTURES = path.join(__dirname, "../../../test-fixtures/ts-lint");
+const CLEAN = path.join(FIXTURES, "clean");
+const DIRTY = path.join(FIXTURES, "dirty");
+
+const NAMING_ERROR = "@typescript-eslint/naming-convention";
+const TYPE_ERROR = "Type 'string' is not assignable to type 'number'";
+
+function copyFixture(name: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "spot-ts-lint-"));
+  fs.cpSync(path.join(FIXTURES, name), dir, { recursive: true });
+  return dir;
+}
+
+describe("tsLint", () => {
+  jest.setTimeout(60000);
+
+  test("reports nothing for a tree that is formatted, clean and type-safe", async () => {
+    const outcome = await tsLint(CLEAN, { fix: false });
+
+    expect(outcome.report).toEqual([]);
+    expect(outcome.fixed).toEqual([]);
+    expect(outcome.ok).toBe(true);
+  });
+
+  test("reports all three kinds of problem from one run", async () => {
+    // The formatting step finding something must not stop the lint or type
+    // steps: a contributor who runs this once should see everything at once.
+    const report = (await tsLint(DIRTY, { fix: false })).report.join("\n");
+
+    expect(report).toContain("Formatting (2):");
+    expect(report).toContain(NAMING_ERROR);
+    expect(report).toContain(TYPE_ERROR);
+  });
+
+  test("does not write to the tree without fix", async () => {
+    const dir = copyFixture("dirty");
+    const before = fs.readFileSync(path.join(dir, "api.ts"), "utf8");
+
+    await tsLint(dir, { fix: false });
+
+    expect(fs.readFileSync(path.join(dir, "api.ts"), "utf8")).toBe(before);
+  });
+
+  test("fix reformats, and leaves the problems it cannot repair", async () => {
+    const dir = copyFixture("dirty");
+
+    const fixRun = await tsLint(dir, { fix: true });
+    expect(fixRun.fixed.map(f => path.basename(f)).sort()).toEqual([
+      "api.ts",
+      "models.ts"
+    ]);
+
+    const afterFix = await tsLint(dir, { fix: false });
+    const report = afterFix.report.join("\n");
+    expect(report).not.toContain("Formatting");
+    // Neither a name nor a type is something a fixer may choose on the
+    // author's behalf, so both survive and the command still fails.
+    expect(report).toContain(NAMING_ERROR);
+    expect(report).toContain(TYPE_ERROR);
+    expect(afterFix.ok).toBe(false);
+  });
+
+  test("ignores lint and formatting config left beside the contract", async () => {
+    const dir = copyFixture("clean");
+    fs.writeFileSync(
+      path.join(dir, ".prettierrc"),
+      JSON.stringify({ singleQuote: false, tabWidth: 8 })
+    );
+    fs.writeFileSync(
+      path.join(dir, "eslint.config.mjs"),
+      "export default [{ rules: { 'no-undef': 'error' } }];\n"
+    );
+
+    const outcome = await tsLint(dir, { fix: false });
+
+    expect(outcome.report).toEqual([]);
+    expect(outcome.ok).toBe(true);
+  });
+
+  test("checks a contract file that nothing imports", async () => {
+    const dir = copyFixture("clean");
+    // Reached by walking the tree, not by following the contract's imports —
+    // an endpoint that has not been wired into api.ts yet is precisely the one
+    // most likely to be unformatted.
+    fs.writeFileSync(path.join(dir, "orphan.ts"), "export const  x = 1;\n");
+
+    const outcome = await tsLint(dir, { fix: false });
+
+    expect(outcome.report.join("\n")).toContain("orphan.ts");
+    expect(outcome.ok).toBe(false);
+  });
+});

--- a/lib/src/ts-lint/ts-lint.ts
+++ b/lib/src/ts-lint/ts-lint.ts
@@ -37,10 +37,8 @@ export async function tsLint(
   const root = path.resolve(dir);
   const files = collectContractFiles(root);
   if (files.length === 0) {
-    // Not a pass. A directory that exists and holds no contracts is what a
-    // renamed tree, an empty bind mount or a partial checkout looks like, and
-    // reporting that as success turns a gate into a no-op that nothing
-    // notices. A directory that does not exist already fails, from readdir.
+    // Not a pass: a renamed tree, an empty bind mount or a partial checkout all
+    // look like this, and calling it success turns the gate into a no-op.
     return {
       report: [
         `No TypeScript files found under ${root}`,
@@ -110,11 +108,12 @@ async function runPrettier(
       // formatted.
       formatted = await format(source, { ...prettierConfig, filepath: file });
     } catch (e) {
-      // Prettier throws on a file it cannot parse, and it is the only step
-      // that does — ESLint reports a parse error as a finding and carries on.
-      // Attribute it and keep going, so one unparseable file does not discard
-      // every finding the other steps have already produced.
-      unparseable.push(`  ${file}: ${(e as Error).message.split("\n")[0]}`);
+      // Unlike the other steps, Prettier throws rather than reporting. Name the
+      // file and keep going, so one bad file does not discard every finding the
+      // other steps have produced. Not `as Error`: a plugin is free to throw
+      // anything, and a throw from in here would take down the whole run.
+      const detail = e instanceof Error ? e.message : String(e);
+      unparseable.push(`  ${file}: ${detail.split("\n")[0]}`);
       continue;
     }
     if (formatted === source) continue;
@@ -204,20 +203,7 @@ function runTypeCheck(files: string[]): string[] {
   files.forEach(file => project.addSourceFileAtPath(file));
   project.resolveSourceFileDependencies();
 
-  // Resolving dependencies pulls in whatever the tree imports, and a declaration
-  // file inside node_modules can carry its own errors. Those are not the
-  // contract author's to fix and --fix cannot reach them, so they would be a
-  // permanent failure a consumer has no move against.
-  //
-  // Only node_modules is excluded. A diagnostic anywhere else — including a
-  // source file above the directory being checked — is about code someone here
-  // can change, and dropping it would mean reporting a tree as clean when it
-  // does not type-check.
-  const diagnostics = project.getPreEmitDiagnostics().filter(diagnostic => {
-    const file = diagnostic.getSourceFile();
-    if (file === undefined) return true;
-    return !file.getFilePath().split(path.posix.sep).includes("node_modules");
-  });
+  const diagnostics = project.getPreEmitDiagnostics();
   if (diagnostics.length === 0) return [];
 
   return [

--- a/lib/src/ts-lint/ts-lint.ts
+++ b/lib/src/ts-lint/ts-lint.ts
@@ -24,21 +24,30 @@ export interface TsLintOptions {
  *
  * Every step runs even when an earlier one has already found something, so a
  * single invocation reports everything wrong with the tree rather than the
- * first category of thing.
+ * first category of thing. A file Prettier cannot parse is reported against
+ * that file and the remaining files are still checked, for the same reason.
  */
 export async function tsLint(
   dir: string,
   { fix }: TsLintOptions
 ): Promise<TsLintOutcome> {
-  // ESLint requires an absolute cwd, and an absolute path is what the report
-  // should name anyway — the caller has usually cd'd somewhere else.
+  // ESLint requires an absolute cwd, and absolute paths are what the report
+  // should name — a relative one is meaningless once the output is read
+  // somewhere other than the directory the command ran in.
   const root = path.resolve(dir);
   const files = collectContractFiles(root);
   if (files.length === 0) {
+    // Not a pass. A directory that exists and holds no contracts is what a
+    // renamed tree, an empty bind mount or a partial checkout looks like, and
+    // reporting that as success turns a gate into a no-op that nothing
+    // notices. A directory that does not exist already fails, from readdir.
     return {
-      report: [`No TypeScript files found under ${root}`],
+      report: [
+        `No TypeScript files found under ${root}`,
+        "  Nothing was checked. Pass the directory holding the contracts."
+      ],
       fixed: [],
-      ok: true
+      ok: false
     };
   }
 
@@ -58,7 +67,8 @@ export async function tsLint(
 }
 
 /**
- * Every `.ts` file under `dir`, skipping `node_modules` and dot-directories.
+ * Every `.ts` file under `dir`, skipping `node_modules` and any entry whose
+ * name begins with a dot.
  *
  * Deliberately a walk of the tree rather than of the contract's import graph:
  * a contract file that nothing imports yet is exactly the file most likely to
@@ -89,10 +99,24 @@ async function runPrettier(
   fixed: Set<string>
 ): Promise<{ report: string[]; ok: boolean }> {
   const unformatted: string[] = [];
+  const unparseable: string[] = [];
 
   for (const file of files) {
     const source = fs.readFileSync(file, "utf8");
-    const formatted = await format(source, prettierConfig);
+    let formatted: string;
+    try {
+      // `filepath` only labels the input for error messages; the parser is
+      // named explicitly in the config, so this cannot change how the file is
+      // formatted.
+      formatted = await format(source, { ...prettierConfig, filepath: file });
+    } catch (e) {
+      // Prettier throws on a file it cannot parse, and it is the only step
+      // that does — ESLint reports a parse error as a finding and carries on.
+      // Attribute it and keep going, so one unparseable file does not discard
+      // every finding the other steps have already produced.
+      unparseable.push(`  ${file}: ${(e as Error).message.split("\n")[0]}`);
+      continue;
+    }
     if (formatted === source) continue;
 
     if (fix) {
@@ -103,15 +127,21 @@ async function runPrettier(
     }
   }
 
-  if (unformatted.length === 0) return { report: [], ok: true };
-
-  return {
-    report: [
+  const report: string[] = [];
+  if (unformatted.length > 0) {
+    report.push(
       `Formatting (${unformatted.length}):`,
       ...unformatted.map(file => `  ${file}`),
       "  Run with --fix to reformat."
-    ],
-    ok: false
+    );
+  }
+  if (unparseable.length > 0) {
+    report.push(`Unparseable (${unparseable.length}):`, ...unparseable);
+  }
+
+  return {
+    report,
+    ok: unformatted.length === 0 && unparseable.length === 0
   };
 }
 
@@ -152,7 +182,9 @@ async function runEslint(
 
   if (lines.length === 0) return { report: [], ok: true };
 
-  // Warnings are reported but never fail the command.
+  // The header counts every message; only errors decide the exit. A
+  // warning-only run therefore reports lines and still passes, which the CLI
+  // distinguishes by not claiming the tree is clean whenever there is a report.
   return {
     report: [`Lint (${lines.length}):`, ...lines],
     ok: errorCount === 0
@@ -160,8 +192,10 @@ async function runEslint(
 }
 
 /**
- * Type-check the contract tree under the same compiler options `parse` uses,
- * so a tree that passes here is a tree `generate` and `validate` can read.
+ * Type-check the contract tree under the same compiler options `parse` uses, so
+ * a tree that clears this step also clears the type-check `parse` performs.
+ * Contract-level errors — a missing `@api`, an unsupported type — are still
+ * `validate`'s job.
  *
  * There is no emit: the diagnostics are the whole product.
  */
@@ -170,7 +204,20 @@ function runTypeCheck(files: string[]): string[] {
   files.forEach(file => project.addSourceFileAtPath(file));
   project.resolveSourceFileDependencies();
 
-  const diagnostics = project.getPreEmitDiagnostics();
+  // Resolving dependencies pulls in whatever the tree imports, and a declaration
+  // file inside node_modules can carry its own errors. Those are not the
+  // contract author's to fix and --fix cannot reach them, so they would be a
+  // permanent failure a consumer has no move against.
+  //
+  // Only node_modules is excluded. A diagnostic anywhere else — including a
+  // source file above the directory being checked — is about code someone here
+  // can change, and dropping it would mean reporting a tree as clean when it
+  // does not type-check.
+  const diagnostics = project.getPreEmitDiagnostics().filter(diagnostic => {
+    const file = diagnostic.getSourceFile();
+    if (file === undefined) return true;
+    return !file.getFilePath().split(path.posix.sep).includes("node_modules");
+  });
   if (diagnostics.length === 0) return [];
 
   return [

--- a/lib/src/ts-lint/ts-lint.ts
+++ b/lib/src/ts-lint/ts-lint.ts
@@ -1,0 +1,189 @@
+import { ESLint } from "eslint";
+import * as fs from "fs";
+import * as path from "path";
+import { format } from "prettier/standalone";
+import { createContractProject } from "../ts-project";
+import { eslintConfig } from "./eslint-config";
+import { prettierConfig } from "./prettier-config";
+
+export interface TsLintOutcome {
+  /** Lines to print, in formatting → lint → type order. */
+  report: string[];
+  /** Paths rewritten under `fix`. */
+  fixed: string[];
+  /** False when a problem that should fail the command remains. */
+  ok: boolean;
+}
+
+export interface TsLintOptions {
+  fix: boolean;
+}
+
+/**
+ * Check a tree of Spot contracts for formatting, lint and type errors.
+ *
+ * Every step runs even when an earlier one has already found something, so a
+ * single invocation reports everything wrong with the tree rather than the
+ * first category of thing.
+ */
+export async function tsLint(
+  dir: string,
+  { fix }: TsLintOptions
+): Promise<TsLintOutcome> {
+  // ESLint requires an absolute cwd, and an absolute path is what the report
+  // should name anyway — the caller has usually cd'd somewhere else.
+  const root = path.resolve(dir);
+  const files = collectContractFiles(root);
+  if (files.length === 0) {
+    return {
+      report: [`No TypeScript files found under ${root}`],
+      fixed: [],
+      ok: true
+    };
+  }
+
+  const fixed = new Set<string>();
+
+  // ESLint fixes before Prettier writes: an ESLint fix produces code, not
+  // layout, so Prettier has to be the one to lay out whatever it produced.
+  const lint = await runEslint(root, files, fix, fixed);
+  const formatting = await runPrettier(files, fix, fixed);
+  const types = runTypeCheck(files);
+
+  return {
+    report: [...formatting.report, ...lint.report, ...types],
+    fixed: [...fixed].sort(),
+    ok: formatting.ok && lint.ok && types.length === 0
+  };
+}
+
+/**
+ * Every `.ts` file under `dir`, skipping `node_modules` and dot-directories.
+ *
+ * Deliberately a walk of the tree rather than of the contract's import graph:
+ * a contract file that nothing imports yet is exactly the file most likely to
+ * be unformatted, and it must not pass by being invisible.
+ */
+function collectContractFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  const walk = (current: string): void => {
+    for (const entry of fs.readdirSync(current, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== "node_modules") walk(full);
+      } else if (entry.name.endsWith(".ts")) {
+        files.push(full);
+      }
+    }
+  };
+
+  walk(dir);
+  return files.sort();
+}
+
+async function runPrettier(
+  files: string[],
+  fix: boolean,
+  fixed: Set<string>
+): Promise<{ report: string[]; ok: boolean }> {
+  const unformatted: string[] = [];
+
+  for (const file of files) {
+    const source = fs.readFileSync(file, "utf8");
+    const formatted = await format(source, prettierConfig);
+    if (formatted === source) continue;
+
+    if (fix) {
+      fs.writeFileSync(file, formatted);
+      fixed.add(file);
+    } else {
+      unformatted.push(file);
+    }
+  }
+
+  if (unformatted.length === 0) return { report: [], ok: true };
+
+  return {
+    report: [
+      `Formatting (${unformatted.length}):`,
+      ...unformatted.map(file => `  ${file}`),
+      "  Run with --fix to reformat."
+    ],
+    ok: false
+  };
+}
+
+async function runEslint(
+  dir: string,
+  files: string[],
+  fix: boolean,
+  fixed: Set<string>
+): Promise<{ report: string[]; ok: boolean }> {
+  const eslint = new ESLint({
+    cwd: dir,
+    // The config is this package's own value and its plugins resolve from this
+    // package's own node_modules, so an eslint.config.* beside the contract is
+    // neither read nor needed.
+    overrideConfigFile: true,
+    overrideConfig: eslintConfig,
+    fix
+  });
+
+  const results = await eslint.lintFiles(files);
+
+  if (fix) {
+    await ESLint.outputFixes(results);
+    results
+      .filter(result => result.output !== undefined)
+      .forEach(result => fixed.add(result.filePath));
+  }
+
+  const errorCount = results.reduce((total, r) => total + r.errorCount, 0);
+  const lines = results.flatMap(result =>
+    result.messages.map(message => {
+      const severity = message.severity === 2 ? "error" : "warning";
+      const position = `${message.line ?? 0}:${message.column ?? 0}`;
+      const rule = message.ruleId === null ? "" : ` (${message.ruleId})`;
+      return `  ${result.filePath}:${position} ${severity} ${message.message}${rule}`;
+    })
+  );
+
+  if (lines.length === 0) return { report: [], ok: true };
+
+  // Warnings are reported but never fail the command.
+  return {
+    report: [`Lint (${lines.length}):`, ...lines],
+    ok: errorCount === 0
+  };
+}
+
+/**
+ * Type-check the contract tree under the same compiler options `parse` uses,
+ * so a tree that passes here is a tree `generate` and `validate` can read.
+ *
+ * There is no emit: the diagnostics are the whole product.
+ */
+function runTypeCheck(files: string[]): string[] {
+  const project = createContractProject();
+  files.forEach(file => project.addSourceFileAtPath(file));
+  project.resolveSourceFileDependencies();
+
+  const diagnostics = project.getPreEmitDiagnostics();
+  if (diagnostics.length === 0) return [];
+
+  return [
+    `Types (${diagnostics.length}):`,
+    ...diagnostics.map(diagnostic => {
+      const messageText = diagnostic.getMessageText();
+      const message =
+        typeof messageText === "string"
+          ? messageText
+          : messageText.getMessageText();
+      const file = diagnostic.getSourceFile()?.getFilePath() ?? "<unknown>";
+      const line = diagnostic.getLineNumber();
+      return `  ${file}${line === undefined ? "" : `:${line}`} - ${message}`;
+    })
+  ];
+}

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -62,10 +62,7 @@ export interface SchemaProp {
 }
 
 export type LiteralType =
-  | BooleanLiteralType
-  | StringLiteralType
-  | FloatLiteralType
-  | IntLiteralType;
+  BooleanLiteralType | StringLiteralType | FloatLiteralType | IntLiteralType;
 
 export interface NullType {
   kind: TypeKind.NULL;

--- a/lib/src/validation-server/spots/validate.ts
+++ b/lib/src/validation-server/spots/validate.ts
@@ -87,14 +87,12 @@ export interface UndefinedRequestHeaderViolation extends ViolationBase {
 }
 
 export interface RequestHeaderTypeDisparityViolation
-  extends ViolationBase,
-    TypeViolationBase {
+  extends ViolationBase, TypeViolationBase {
   type: "request_header_type_disparity";
 }
 
 export interface PathParamTypeDisparityViolation
-  extends ViolationBase,
-    TypeViolationBase {
+  extends ViolationBase, TypeViolationBase {
   type: "path_param_type_disparity";
 }
 
@@ -107,8 +105,7 @@ export interface UndefinedQueryParamViolation extends ViolationBase {
 }
 
 export interface QueryParamTypeDisparityViolation
-  extends ViolationBase,
-    TypeViolationBase {
+  extends ViolationBase, TypeViolationBase {
   type: "query_param_type_disparity";
 }
 
@@ -117,8 +114,7 @@ export interface UndefinedRequestBodyViolation extends ViolationBase {
 }
 
 export interface RequestBodyTypeDisparityViolation
-  extends ViolationBase,
-    TypeViolationBase {
+  extends ViolationBase, TypeViolationBase {
   type: "request_body_type_disparity";
 }
 
@@ -131,8 +127,7 @@ export interface UndefinedResponseHeaderViolation extends ViolationBase {
 }
 
 export interface ResponseHeaderTypeDisparityViolation
-  extends ViolationBase,
-    TypeViolationBase {
+  extends ViolationBase, TypeViolationBase {
   type: "response_header_type_disparity";
 }
 
@@ -141,7 +136,6 @@ export interface UndefinedResponseBodyViolation extends ViolationBase {
 }
 
 export interface ResponseBodyTypeDisparityViolation
-  extends ViolationBase,
-    TypeViolationBase {
+  extends ViolationBase, TypeViolationBase {
   type: "response_body_type_disparity";
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "bugs": "https://github.com/airtasker/spot/issues",
   "dependencies": {
+    "@eslint/js": "^10.0.1",
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@oclif/errors": "^1.3.6",
@@ -16,18 +17,21 @@
     "ajv-formats": "^2.1.1",
     "assert-never": "^1.4.0",
     "cors": "^2.8.5",
+    "eslint": "^10.8.1",
+    "eslint-config-prettier": "^10.1.8",
     "express": "^4.19.2",
     "fs-extra": "^11.4.0",
     "inquirer": "^8.1.1",
     "js-yaml": "^4.3.1",
+    "prettier": "^3.9.6",
     "qs": "^6.15.3",
     "randomstring": "^1.3.1",
     "ts-morph": "18.0.0",
     "typescript": "^4.9.5",
+    "typescript-eslint": "^8.67.0",
     "validator": "^13.12.0"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
     "@oclif/dev-cli": "^1.26.0",
     "@stoplight/spectral": "^5.9.2",
     "@types/cors": "^2.8.17",
@@ -40,16 +44,13 @@
     "@types/randomstring": "^1.3.0",
     "@types/supertest": "^6.0.0",
     "@types/validator": "^13.11.10",
-    "eslint": "^10.8.1",
     "eslint-plugin-jest": "^29.16.1",
     "globals": "^17.9.0",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "nock": "^14.0.17",
-    "prettier": "^3.3.2",
     "supertest": "^7.1.3",
-    "ts-jest": "^29.4.12",
-    "typescript-eslint": "^8.67.0"
+    "ts-jest": "^29.4.12"
   },
   "engines": {
     "node": ">=18.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      '@eslint/js':
+        specifier: ^10.0.1
+        version: 10.0.1(eslint@10.8.1)
       '@oclif/command':
         specifier: ^1.8.0
         version: 1.8.36(@oclif/config@1.18.17)
@@ -39,6 +42,12 @@ importers:
       cors:
         specifier: ^2.8.5
         version: 2.8.5
+      eslint:
+        specifier: ^10.8.1
+        version: 10.8.1
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@10.8.1)
       express:
         specifier: ^4.19.2
         version: 4.19.2
@@ -51,6 +60,9 @@ importers:
       js-yaml:
         specifier: ^4.3.1
         version: 4.3.1
+      prettier:
+        specifier: ^3.9.6
+        version: 3.9.6
       qs:
         specifier: ^6.15.3
         version: 6.15.3
@@ -63,13 +75,13 @@ importers:
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
+      typescript-eslint:
+        specifier: ^8.67.0
+        version: 8.67.0(eslint@10.8.1)(typescript@4.9.5)
       validator:
         specifier: ^13.12.0
         version: 13.12.0
     devDependencies:
-      '@eslint/js':
-        specifier: ^10.0.1
-        version: 10.0.1(eslint@10.8.1)
       '@oclif/dev-cli':
         specifier: ^1.26.0
         version: 1.26.10
@@ -106,9 +118,6 @@ importers:
       '@types/validator':
         specifier: ^13.11.10
         version: 13.11.10
-      eslint:
-        specifier: ^10.8.1
-        version: 10.8.1
       eslint-plugin-jest:
         specifier: ^29.16.1
         version: 29.16.1(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(jest@29.7.0(@types/node@20.8.4)(node-notifier@8.0.2))(typescript@4.9.5)
@@ -124,18 +133,12 @@ importers:
       nock:
         specifier: ^14.0.17
         version: 14.0.17
-      prettier:
-        specifier: ^3.3.2
-        version: 3.3.2
       supertest:
         specifier: ^7.1.3
         version: 7.2.2
       ts-jest:
         specifier: ^29.4.12
         version: 29.4.12(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.8.4)(node-notifier@8.0.2))(typescript@4.9.5)
-      typescript-eslint:
-        specifier: ^8.67.0
-        version: 8.67.0(eslint@10.8.1)(typescript@4.9.5)
 
   docs:
     devDependencies:
@@ -1798,6 +1801,12 @@ packages:
     engines: {node: '>=4.0'}
     hasBin: true
 
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
   eslint-plugin-jest@29.16.1:
     resolution: {integrity: sha512-tfxOIsjzaBud+f74aLbBMRcnrztt5eCIgnAdeoGdnzMAQ4IdAa/s/p8Ls55mk9MC79N3j2jbv4Qetz6Hclbcfw==}
     engines: {node: ^20.12.0 || ^22.0.0 || >=24.0.0}
@@ -3142,8 +3151,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.3.2:
-    resolution: {integrity: sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==}
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -6149,6 +6158,10 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
+  eslint-config-prettier@10.1.8(eslint@10.8.1):
+    dependencies:
+      eslint: 10.8.1
+
   eslint-plugin-jest@29.16.1(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(jest@29.7.0(@types/node@20.8.4)(node-notifier@8.0.2))(typescript@4.9.5):
     dependencies:
       '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@4.9.5)
@@ -7702,7 +7715,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.3.2: {}
+  prettier@3.9.6: {}
 
   pretty-error@4.0.0:
     dependencies:

--- a/test-fixtures/ts-lint/clean/api.ts
+++ b/test-fixtures/ts-lint/clean/api.ts
@@ -1,0 +1,87 @@
+import {
+  api,
+  body,
+  DateTime,
+  defaultResponse,
+  endpoint,
+  Float,
+  headers,
+  pathParams,
+  request,
+  response,
+  securityHeader,
+  String
+} from '@airtasker/spot';
+import './list-widgets';
+import { ErrorBody, WidgetBody } from './models';
+
+/** A widget catalogue. */
+@api({ name: 'widget-api' })
+class WidgetApi {
+  @securityHeader
+  'x-auth-token': String;
+}
+
+/** Creates a widget in a catalogue */
+@endpoint({
+  method: 'POST',
+  path: '/catalogues/:catalogueId/widgets',
+  tags: ['Widget']
+})
+class CreateWidget {
+  @request
+  request(
+    @pathParams
+    pathParams: {
+      /** catalogue identifier */
+      catalogueId: String;
+    },
+    @headers
+    headers: {
+      /** Auth header */
+      'x-auth-token': String;
+    },
+    /** request body */
+    @body body: CreateWidgetRequestBody
+  ) {}
+
+  /** The widget was created */
+  @response({ status: 201 })
+  successResponse(
+    @headers
+    headers: {
+      /** Location of the created widget */
+      Location: String;
+    },
+    /** Widget response body */
+    @body body: WidgetBody
+  ) {}
+
+  /** The request was malformed */
+  @response({ status: 400 })
+  badRequestResponse(
+    /** Error response body */
+    @body body: ErrorBody
+  ) {}
+
+  @defaultResponse
+  unexpectedResponse(
+    /** Error response body */
+    @body body: ErrorBody
+  ) {}
+}
+
+/** Widget creation request body */
+interface CreateWidgetRequestBody {
+  /** data wrapper */
+  data: {
+    /** display name */
+    name: String;
+    /** price in cents */
+    priceCents: Float;
+    /** when the widget becomes orderable */
+    availableFrom?: DateTime;
+    /** free-form labels */
+    tags: String[];
+  };
+}

--- a/test-fixtures/ts-lint/clean/api.ts
+++ b/test-fixtures/ts-lint/clean/api.ts
@@ -1,3 +1,6 @@
+// The same contract as test-fixtures/contract/, in the canonical contract style
+// this command enforces — single quotes, where the repo's own config uses double.
+// Extend both together, or this stops representing a current contract.
 import {
   api,
   body,

--- a/test-fixtures/ts-lint/clean/list-widgets.ts
+++ b/test-fixtures/ts-lint/clean/list-widgets.ts
@@ -1,0 +1,54 @@
+import {
+  body,
+  endpoint,
+  headers,
+  pathParams,
+  queryParams,
+  request,
+  response,
+  String
+} from '@airtasker/spot';
+import { ErrorBody, WidgetListBody } from './models';
+
+/** Lists the widgets in a catalogue */
+@endpoint({
+  method: 'GET',
+  path: '/catalogues/:catalogueId/widgets',
+  tags: ['Widget']
+})
+class ListWidgets {
+  @request
+  request(
+    @pathParams
+    pathParams: {
+      /** catalogue identifier */
+      catalogueId: String;
+    },
+    @headers
+    headers: {
+      /** Auth header */
+      'x-auth-token': String;
+    },
+    @queryParams
+    queryParams: {
+      /** only return widgets carrying this tag */
+      tag?: String;
+      /** maximum number of widgets to return */
+      limit?: number;
+    }
+  ) {}
+
+  /** The matching widgets */
+  @response({ status: 200 })
+  successResponse(
+    /** Widget collection response body */
+    @body body: WidgetListBody
+  ) {}
+
+  /** The catalogue does not exist */
+  @response({ status: 404 })
+  notFoundResponse(
+    /** Error response body */
+    @body body: ErrorBody
+  ) {}
+}

--- a/test-fixtures/ts-lint/clean/models.ts
+++ b/test-fixtures/ts-lint/clean/models.ts
@@ -1,0 +1,33 @@
+/** A widget */
+export interface Widget {
+  /** widget identifier */
+  id: string;
+  /** display name */
+  name: string;
+  /** price in cents */
+  priceCents: number;
+  /** whether the widget is orderable */
+  available: boolean;
+  /** free-form labels */
+  tags: string[];
+}
+
+/** Widget response body */
+export interface WidgetBody {
+  /** data wrapper */
+  data: Widget;
+}
+
+/** Widget collection response body */
+export interface WidgetListBody {
+  /** data wrapper */
+  data: Widget[];
+}
+
+/** Error body */
+export interface ErrorBody {
+  /** error name */
+  name: string;
+  /** error messages */
+  messages: string[];
+}

--- a/test-fixtures/ts-lint/dirty/api.ts
+++ b/test-fixtures/ts-lint/dirty/api.ts
@@ -1,0 +1,57 @@
+import {
+  api,
+  body,
+  endpoint,
+  headers,
+  pathParams,
+  request,
+  response,
+  securityHeader,
+  String
+} from "@airtasker/spot";
+import { ErrorBody, WidgetBody } from "./models";
+
+/** A widget catalogue. */
+@api({ name: 'widget-api' })
+class WidgetApi {
+  @securityHeader
+  'x-auth-token': String;
+}
+
+/** Creates a widget in a catalogue */
+@endpoint({
+  method: 'POST',
+  path: '/catalogues/:catalogueId/widgets',
+  tags: ['Widget']
+})
+class CreateWidget {
+  @request
+  request(
+    @pathParams
+    pathParams: {
+      /** catalogue identifier */
+      catalogueId: String;
+    },
+      @headers
+      headers: {
+        /** Auth header */
+        'x-auth-token': String;
+      },
+    /** request body */
+    @body body: WidgetBody
+  ) {}
+
+  /** The widget was created */
+  @response({ status: 201 })
+  successResponse(
+    /** Widget response body */
+    @body body: WidgetBody
+  ) {}
+
+  /** The request was malformed */
+  @response({ status: 400 })
+  badRequestResponse(
+    /** Error response body */
+    @body body: ErrorBody
+  ) {}
+}

--- a/test-fixtures/ts-lint/dirty/models.ts
+++ b/test-fixtures/ts-lint/dirty/models.ts
@@ -1,0 +1,34 @@
+/** A widget */
+export interface Widget {
+  /** widget identifier */
+  id: string;
+  /** display name */
+  name: string;
+  /** price in cents */
+  priceCents: number;
+}
+
+/** Widget response body */
+export interface WidgetBody {
+  /** data wrapper */
+      data: Widget;
+}
+
+/** Error body */
+export interface ErrorBody {
+  /** error name */
+  name: string;
+  /** error messages */
+  messages: string[];
+}
+
+// Not camelCase or PascalCase: `naming-convention` reports this, and no
+// `--fix` can repair it.
+const DEFAULT_price = 100;
+
+// `priceCents` is a number, so this is the tree's only type error.
+export const sample: Widget = {
+  id: 'w-1',
+  name: 'Widget',
+  priceCents: DEFAULT_price + 'c'
+};


### PR DESCRIPTION
## Ticket

[COMPASS-17](https://airtasker.atlassian.net/browse/COMPASS-17) — Change `spot` to be interacted with as a docker image rather than as a NodeJS tool

> **Stacked on #2710 → #2709 → #2708.** Review those first. `build-and-test` does report on this PR — `test-node-{18,20,22,24}` and `lint-check` are green.

## What

`spot ts-lint [directory] [--fix]` — checks a tree of Spot contracts for formatting, lint and type errors, under configuration Spot carries itself.

```
$ spot ts-lint spots
Formatting (2):
  /repo/spots/api.ts
  /repo/spots/models.ts
  Run with --fix to reformat.
Lint (1):
  /repo/spots/models.ts:27:7 error Variable name `DEFAULT_price` must match one of the following formats: camelCase, PascalCase (@typescript-eslint/naming-convention)
Types (1):
  /repo/spots/models.ts:33 - Type 'string' is not assignable to type 'number'.
```

## Why

This is what lets the three consumer repos delete their contract Node toolchains. Today each one installs prettier, eslint, typescript-eslint and a tsconfig purely to check contracts, and carries a near-identical `eslint.config.mjs` and `.prettierrc.yml` to configure them. Bundling the tools *and* the configuration into Spot means a consumer needs none of it — just the container.

## Design

**Three steps, all of which run even when an earlier one has already found something.** A contributor who runs this once should see everything wrong with the tree, not the first category of thing.

1. **Prettier**, via `prettier/standalone` with the TypeScript and estree plugins passed explicitly. Neither config discovery nor plugin resolution is used, so a `.prettierrc` left behind in a consumer repo cannot change how contracts are formatted. (This also avoids the dynamic `import()` in prettier's default CJS entrypoint, which does not work under jest's VM without `--experimental-vm-modules`.)
2. **ESLint**, via the programmatic API with `overrideConfigFile: true` and the config as an **in-code value**, not a path. Its plugins are the ones the config module imported, so they resolve from Spot's own `node_modules`; there is no `--config` path semantics and no `resolvePluginsRelativeTo`, and a leftover `eslint.config.mjs` beside the contract is neither read nor needed.
3. **A type check through ts-morph**, under the same compiler options `parse` uses — including the `@airtasker/spot` mapping fixed in #2708. There is no emit by construction; the diagnostics are the whole product. This is what replaces rails-monolith's `pnpm tsc --outDir output` gate, whose `output/` directory nothing ever consumed.

**Exit codes.** 0 when clean or fully fixed; 1 for any remaining formatting difference, lint error, or type error, and 1 when the directory holds no `.ts` files at all — a renamed tree or an empty bind mount must not read as a pass. Set through `process.exitCode`, not `process.exit`: `this.log` writes asynchronously when stdout is a pipe, so exiting outright truncated the report (three identical runs of a 1601-line report printed 770, 1601 and 577 lines). Warnings are printed and never fail, and "No problems found" is withheld whenever there is a report to show.

**File discovery is a walk of the tree, not of the import graph** — every `.ts` under the directory, skipping `node_modules` and dot-directories. A contract file that nothing imports yet is exactly the file most likely to be unformatted, and it must not pass by being invisible. There is a test for this.

**Under `--fix`, ESLint's fixes are applied before Prettier writes.** An ESLint fix produces code, not layout, so Prettier has to be the one to lay out whatever it produced. Doing it the other way round leaves a tree that `--fix` claims to have fixed and that fails on the next run.

## The canonical config

Reconciled from the three consumers' real configs, not designed fresh.

**Formatting.** All three consumers already share an identical `.prettierrc.yml`: `trailingComma: none`, `tabWidth: 2`, `semi: true`, `singleQuote: true`, `printWidth: 80`. That is the canonical config. It is worth being explicit that this is **not** Prettier's default — the plan for this ticket called for defaults plus an accepted one-off reformat, but adopting what the consumers already use means no reformat at all in two of the three repos, and removes the "reformat races contract churn" risk from the plan's risk table.

**Rules.** The union of the three configs' rule-offs, plus the `naming-convention` rule that bff-client and enrichment-engine carry and rails-monolith does not. `@typescript-eslint/ban-types` was split in typescript-eslint 8, so its single `off` becomes `no-empty-object-type`, `no-wrapper-object-types` and `no-unsafe-function-type`.

On `no-wrapper-object-types` specifically, the reasoning in the first version of this PR was wrong and the comment has been corrected. A contract imports `String` and `Boolean` from `@airtasker/spot`, and that import shadows the global — so the rule has nothing to say about a well-formed contract either way. Turned on against the clean fixture, which uses `String` in path params, headers and query params, it reports nothing. What the exemption actually suppresses is the opposite case: a file naming the global because the import is missing. That is a real mistake, and it is caught where it has consequences, by the parser rejecting the type.

**`eslint-plugin-prettier` is dropped.** Formatting failures surface from the Prettier step instead of a second time as a lint rule. Same gate, one report each.

**Prettier moves 3.3.2 → 3.9.6**, the version the consumers are on. 3.9 collapses short unions onto one line, so this reformats five of Spot's own files.

## How this was verified

**Against the three real consumer contract trees.** This is the reconciliation the plan requires before any consumer migration PR is written, so the canonical config is fixed here:

| Repo | Files | Formatting | Lint | Types |
|---|---|---|---|---|
| `rails-monolith/spots` | 230 | clean | clean | clean |
| `bff-client/…/spots` | 345 | **29 reformat** | clean | clean |
| `enrichment-engine/spots` | 4 | clean | clean | clean |

- **No consumer gains a lint error** — including rails-monolith, which does not have `naming-convention` today and passes it anyway.
- **No consumer gains a type error**, so the type step can replace rails' `tsc` gate without introducing failures. (Expected: `validate`/`generate` already parse with `strict: true`.)
- bff-client's 29 files are the same union-wrapping change and nothing else; it is pinned to prettier 3.8.3. That is the whole reformat cost of this migration, across all three repos.
- The plan predicted enrichment-engine would take "the largest style delta — 4-space→canonical". It takes none; its contracts are already 2-space. The 4-space file is its `eslint.config.mjs`, which is being deleted anyway.

**Other checks:**

- `pnpm test` — 541 tests across 50 suites pass, including 12 new ones.
- **The Prettier bump changes no behaviour**: compiled `build/` output is byte-identical to the parent branch apart from the new `ts-lint` files.
- `node bin/run ts-lint test-fixtures/ts-lint/clean` exits 0. `dirty` exits 1 reporting all three categories from one run. `--fix` then clears the formatting and leaves the naming-convention error and the type error standing — neither is something a fixer may decide on the author's behalf — and the command still exits 1.
- A test writes a `.prettierrc` with `singleQuote: false` and an `eslint.config.mjs` into the fixture tree and asserts the outcome is unchanged. That is the load-bearing claim of the in-code-config design, so it has a test rather than a comment. **The ESLint half of that test needed a different rule to mean anything:** it originally used `no-undef`, which `tseslint.configs.recommended` switches off again from inside `overrideConfig`, so it reported nothing whether or not the leftover config was read. It now uses `no-restricted-syntax` on `TSInterfaceDeclaration`, a rule the bundled config never mentions — verified to report 5 findings on the clean fixture when applied, and 0 as shipped.
- A test asserts a non-`--fix` run does not write to the tree.

## Notes

- `test-fixtures/ts-lint/` is excluded from Spot's own prettier and eslint runs. Those trees are held to the *canonical contract* config, which differs from this repo's own (single vs double quotes), and `dirty/` is deliberately broken.
- **No TypeScript bump.** The plan budgeted `typescript` 4.9 → 5 as this PR's riskiest commit, on the assumption typescript-eslint 8 would force it. Its peer range is `>=4.8.4 <6.1.0`, so it does not. Likewise the eslint `^9` fallback the plan designed for is not needed — `^10` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[COMPASS-17]: https://airtasker.atlassian.net/browse/COMPASS-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
