### PR TITLE
fix(COMPASS-17): fail fast when generate runs without a terminal

### DIFF
--- a/cli/src/commands/generate.spec.ts
+++ b/cli/src/commands/generate.spec.ts
@@ -1,7 +1,12 @@
 import * as fs from "fs";
+import { prompt } from "inquirer";
 import * as os from "os";
 import * as path from "path";
 import Generate from "./generate";
+
+jest.mock("inquirer", () => ({ prompt: jest.fn() }));
+
+const promptMock = prompt as unknown as jest.Mock;
 
 const CONTRACT = path.join(__dirname, "../../../test-fixtures/contract/api.ts");
 
@@ -12,11 +17,16 @@ describe("generate", () => {
 
   afterEach(() => {
     process.stdin.isTTY = realIsTTY;
+    promptMock.mockReset();
     jest.restoreAllMocks();
   });
 
   function withoutTerminal(): void {
     process.stdin.isTTY = false;
+  }
+
+  function withTerminal(): void {
+    process.stdin.isTTY = true;
   }
 
   async function failureFrom(argv: string[]): Promise<Error> {
@@ -90,5 +100,24 @@ describe("generate", () => {
     expect(log.mock.calls.map(call => String(call[0])).join("")).toContain(
       `Generated ${written}`
     );
+  });
+  test("prompts for the missing flags when there is a terminal", async () => {
+    // The other cases all sit on the no-terminal side of the guard, so without
+    // this one the condition itself is unconstrained: making it unconditional
+    // keeps them all green while destroying every interactive invocation.
+    withTerminal();
+    const outDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "spot-generate-tty-"))
+    );
+    promptMock
+      .mockResolvedValueOnce({ Generator: "openapi3" })
+      .mockResolvedValueOnce({ Language: "yaml" })
+      .mockResolvedValueOnce({ "Output destination": outDir });
+    jest.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    await Generate.run(["-c", CONTRACT]);
+
+    expect(promptMock).toHaveBeenCalledTimes(3);
+    expect(fs.existsSync(path.join(outDir, "api.yml"))).toBe(true);
   });
 });

--- a/cli/src/commands/generate.spec.ts
+++ b/cli/src/commands/generate.spec.ts
@@ -1,0 +1,94 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import Generate from "./generate";
+
+const CONTRACT = path.join(__dirname, "../../../test-fixtures/contract/api.ts");
+
+describe("generate", () => {
+  jest.setTimeout(60000);
+
+  const realIsTTY = process.stdin.isTTY;
+
+  afterEach(() => {
+    process.stdin.isTTY = realIsTTY;
+    jest.restoreAllMocks();
+  });
+
+  function withoutTerminal(): void {
+    process.stdin.isTTY = false;
+  }
+
+  async function failureFrom(argv: string[]): Promise<Error> {
+    try {
+      await Generate.run(argv);
+    } catch (e) {
+      return e as Error;
+    }
+    throw new Error(`Expected generate ${argv.join(" ")} to fail`);
+  }
+
+  test("exits 2 rather than prompting when there is no terminal", async () => {
+    withoutTerminal();
+
+    await expect(Generate.run(["-c", CONTRACT])).rejects.toMatchObject({
+      oclif: { exit: 2 }
+    });
+  });
+
+  test("names every missing flag, not just the first one", async () => {
+    withoutTerminal();
+
+    // One run should be enough for a caller to fix its invocation. Reporting
+    // only `--generator` sends them round the loop three times.
+    const error = await failureFrom(["-c", CONTRACT]);
+
+    expect(error.message).toContain("--generator (-g)");
+    expect(error.message).toContain("--language (-l)");
+    expect(error.message).toContain("--out (-o)");
+  });
+
+  test("names only the flags that are actually missing", async () => {
+    withoutTerminal();
+
+    const error = await failureFrom([
+      "-c",
+      CONTRACT,
+      "-g",
+      "openapi3",
+      "-l",
+      "yaml"
+    ]);
+
+    expect(error.message).toContain("--out (-o)");
+    expect(error.message).not.toContain("--generator");
+    expect(error.message).not.toContain("--language");
+  });
+
+  test("reports the file it wrote, not the directory it was given", async () => {
+    withoutTerminal();
+    // realpath because macOS reaches the temp directory through a symlink,
+    // and the command reports the resolved path.
+    const outDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "spot-generate-"))
+    );
+    const log = jest.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    await Generate.run([
+      "-c",
+      CONTRACT,
+      "-g",
+      "openapi3",
+      "-l",
+      "yaml",
+      "-o",
+      outDir
+    ]);
+
+    const written = path.join(outDir, "api.yml");
+    expect(fs.existsSync(written)).toBe(true);
+    expect(log.mock.calls.map(call => String(call[0])).join("")).toContain(
+      `Generated ${written}`
+    );
+  });
+});

--- a/cli/src/commands/generate.ts
+++ b/cli/src/commands/generate.ts
@@ -6,7 +6,7 @@ import { Contract } from "../../../lib/src/definitions";
 import { generateJsonSchema } from "../../../lib/src/generators/json-schema/json-schema";
 import { generateOpenAPI2 } from "../../../lib/src/generators/openapi2/openapi2";
 import { generateOpenAPI3 } from "../../../lib/src/generators/openapi3/openapi3";
-import { outputFile } from "../../../lib/src/io/output";
+import { outputFile, resolveOutputPath } from "../../../lib/src/io/output";
 import { parse } from "../../../lib/src/parser";
 
 export default class Generate extends Command {
@@ -43,6 +43,28 @@ export default class Generate extends Command {
     const { contract: contractPath } = flags;
     let { language, generator, out: outDir } = flags;
     const contractFilename = path.basename(contractPath, ".ts");
+
+    // Each missing flag below falls back to an interactive prompt. With no
+    // terminal — a CI step, a Gradle exec, a docker run without `-it` — that
+    // prompt has nothing to read from, so the command hangs or exits on a
+    // silently empty answer. Name every missing flag at once, so a caller
+    // fixes its invocation in one pass rather than one flag per run.
+    if (!process.stdin.isTTY) {
+      const missing = [
+        generator ? null : "--generator (-g)",
+        language ? null : "--language (-l)",
+        outDir ? null : "--out (-o)"
+      ].filter((flag): flag is string => flag !== null);
+
+      if (missing.length > 0) {
+        this.error(
+          `Cannot prompt for ${missing.join(
+            ", "
+          )} without a terminal. Pass every flag explicitly when running non-interactively.`,
+          { exit: 2 }
+        );
+      }
+    }
 
     if (!generator) {
       generator = (
@@ -108,11 +130,10 @@ export default class Generate extends Command {
     const transformedContract = generatorTransformer(parse(contractPath));
     const formattedContract = formatTransformer(transformedContract);
 
-    outputFile(
-      outDir,
-      `${contractFilename}.${formatExtension}`,
-      formattedContract
-    );
+    const outputName = `${contractFilename}.${formatExtension}`;
+    outputFile(outDir, outputName, formattedContract);
+
+    this.log(`Generated ${resolveOutputPath(outDir, outputName)}`);
   }
 }
 

--- a/cli/src/commands/generate.ts
+++ b/cli/src/commands/generate.ts
@@ -44,11 +44,12 @@ export default class Generate extends Command {
     let { language, generator, out: outDir } = flags;
     const contractFilename = path.basename(contractPath, ".ts");
 
-    // Each missing flag below falls back to an interactive prompt. With no
-    // terminal — a CI step, a Gradle exec, a docker run without `-it` — that
-    // prompt has nothing to read from, so the command hangs or exits on a
-    // silently empty answer. Name every missing flag at once, so a caller
-    // fixes its invocation in one pass rather than one flag per run.
+    // Each missing flag below falls back to an interactive prompt, reading
+    // stdin. With no terminal — a CI step, a Gradle exec, a docker run without
+    // `-it` — inquirer still renders and waits on a line event that never
+    // arrives, so the command hangs until whatever is running it gives up.
+    // Name every missing flag at once, so a caller fixes its invocation in one
+    // pass rather than one flag per run.
     if (!process.stdin.isTTY) {
       const missing = [
         generator ? null : "--generator (-g)",

--- a/cli/src/commands/generate.ts
+++ b/cli/src/commands/generate.ts
@@ -45,9 +45,11 @@ export default class Generate extends Command {
     const contractFilename = path.basename(contractPath, ".ts");
 
     // Each missing flag below falls back to an interactive prompt, reading
-    // stdin. With no terminal — a CI step, a Gradle exec, a docker run without
-    // `-it` — inquirer still renders and waits on a line event that never
-    // arrives, so the command hangs until whatever is running it gives up.
+    // stdin. With no terminal the answer never arrives, and how that presents
+    // depends on the stdin given: at EOF (docker run without `-i`) the prompt
+    // never settles and the process exits having generated nothing; an open but
+    // silent pipe (a CI step, a Gradle exec) hangs; a pipe carrying newlines
+    // takes the first choice and generates the wrong artifact with exit 0.
     // Name every missing flag at once, so a caller fixes its invocation in one
     // pass rather than one flag per run.
     if (!process.stdin.isTTY) {

--- a/cli/src/commands/validation-server.spec.ts
+++ b/cli/src/commands/validation-server.spec.ts
@@ -1,0 +1,11 @@
+import { READY_LINE_PREFIX } from "./validation-server";
+
+describe("validation-server", () => {
+  test("the readiness prefix downstream builds block on is unchanged", () => {
+    // Not a tautology: it is the only thing in this repository that fails when
+    // the string is reworded. Without it a rename passes review and CI here,
+    // and surfaces as a timed-out build in another repository with no
+    // diagnostic pointing back at this line.
+    expect(READY_LINE_PREFIX).toBe("Validation server running");
+  });
+});

--- a/cli/src/commands/validation-server.spec.ts
+++ b/cli/src/commands/validation-server.spec.ts
@@ -2,10 +2,8 @@ import { READY_LINE_PREFIX } from "./validation-server";
 
 describe("validation-server", () => {
   test("the readiness prefix downstream builds block on is unchanged", () => {
-    // Not a tautology: it is the only thing in this repository that fails when
-    // the string is reworded. Without it a rename passes review and CI here,
-    // and surfaces as a timed-out build in another repository with no
-    // diagnostic pointing back at this line.
+    // A rename otherwise passes review and CI here, and surfaces as a
+    // timed-out build in another repository with nothing pointing back here.
     expect(READY_LINE_PREFIX).toBe("Validation server running");
   });
 });

--- a/cli/src/commands/validation-server.ts
+++ b/cli/src/commands/validation-server.ts
@@ -41,6 +41,9 @@ export default class ValidationServer extends Command {
 
       this.log("Starting validation server...");
       await runValidationServer(port, contract).defer();
+      // Load-bearing readiness line: bff-client's Gradle ExecFork task blocks
+      // on the "Validation server running" prefix before it runs the contract
+      // tests. Reword it and that build waits until it times out.
       this.log(`Validation server running on port ${port}`);
     } catch (e) {
       this.error(e as Error, { exit: 1 });

--- a/cli/src/commands/validation-server.ts
+++ b/cli/src/commands/validation-server.ts
@@ -5,6 +5,14 @@ import { runValidationServer } from "../../../lib/src/validation-server/server";
 const ARG_API = "spot_contract";
 
 /**
+ * Machine-parsed readiness signal. Downstream builds block on this exact prefix
+ * before they run against the server, and a build that never sees it waits until
+ * it times out with nothing else to go on — so the string is a wire contract,
+ * not log text. Pinned by a spec for that reason.
+ */
+export const READY_LINE_PREFIX = "Validation server running";
+
+/**
  * oclif command to start the spot contract validation server
  */
 export default class ValidationServer extends Command {
@@ -41,10 +49,7 @@ export default class ValidationServer extends Command {
 
       this.log("Starting validation server...");
       await runValidationServer(port, contract).defer();
-      // Load-bearing readiness line: bff-client's Gradle ExecFork task blocks
-      // on the "Validation server running" prefix before it runs the contract
-      // tests. Reword it and that build waits until it times out.
-      this.log(`Validation server running on port ${port}`);
+      this.log(`${READY_LINE_PREFIX} on port ${port}`);
     } catch (e) {
       this.error(e as Error, { exit: 1 });
     }

--- a/lib/src/io/output.spec.ts
+++ b/lib/src/io/output.spec.ts
@@ -23,10 +23,8 @@ describe("resolveOutputPath", () => {
     );
   });
   test("an absolute relativePath wins over the output directory", () => {
-    // This is what distinguishes path.resolve from path.join here. Every caller
-    // today passes a bare filename, so the two agree; pinning it means a future
-    // caller that passes an absolute path gets the decided behaviour rather than
-    // whichever one happens to be in place.
+    // What distinguishes path.resolve from path.join here; every caller today
+    // passes a bare filename, so the two otherwise agree.
     expect(resolveOutputPath("/srv/contracts", "/etc/spot/api.yml")).toBe(
       "/etc/spot/api.yml"
     );

--- a/lib/src/io/output.spec.ts
+++ b/lib/src/io/output.spec.ts
@@ -22,4 +22,13 @@ describe("resolveOutputPath", () => {
       path.join(os.homedir(), "contracts/api.yml")
     );
   });
+  test("an absolute relativePath wins over the output directory", () => {
+    // This is what distinguishes path.resolve from path.join here. Every caller
+    // today passes a bare filename, so the two agree; pinning it means a future
+    // caller that passes an absolute path gets the decided behaviour rather than
+    // whichever one happens to be in place.
+    expect(resolveOutputPath("/srv/contracts", "/etc/spot/api.yml")).toBe(
+      "/etc/spot/api.yml"
+    );
+  });
 });

--- a/lib/src/io/output.spec.ts
+++ b/lib/src/io/output.spec.ts
@@ -1,0 +1,25 @@
+import * as os from "os";
+import * as path from "path";
+import { resolveOutputPath } from "./output";
+
+describe("resolveOutputPath", () => {
+  test("resolves a relative directory against the working directory", () => {
+    expect(resolveOutputPath("doc/output", "api.yml")).toBe(
+      path.join(process.cwd(), "doc/output/api.yml")
+    );
+  });
+
+  test("keeps an absolute directory", () => {
+    expect(resolveOutputPath("/srv/contracts", "api.yml")).toBe(
+      "/srv/contracts/api.yml"
+    );
+  });
+
+  test("expands a tilde against the home directory of this process", () => {
+    // Not the caller's home, when Spot is a container: the one reported here
+    // is the container's, which is why the path is worth printing at all.
+    expect(resolveOutputPath("~/contracts", "api.yml")).toBe(
+      path.join(os.homedir(), "contracts/api.yml")
+    );
+  });
+});

--- a/lib/src/io/output.ts
+++ b/lib/src/io/output.ts
@@ -2,13 +2,27 @@ import fs from "fs-extra";
 import path from "path";
 import { expandPathWithTilde } from "../utilities/expand-path-with-tilde";
 
+/**
+ * Where `outputFile` writes, as an absolute path.
+ *
+ * Worth reporting to the user rather than echoing back what they typed: `~`
+ * expands against the home directory of whatever is running Spot, which under
+ * a container is the container's, not theirs.
+ */
+export function resolveOutputPath(
+  outDir: string,
+  relativePath: string
+): string {
+  return path.resolve(expandPathWithTilde(outDir), relativePath);
+}
+
 export function outputFile(
   outDir: string,
   relativePath: string,
   content: string,
   override = true
 ): boolean {
-  const destinationPath = path.join(expandPathWithTilde(outDir), relativePath);
+  const destinationPath = resolveOutputPath(outDir, relativePath);
   fs.mkdirpSync(path.dirname(destinationPath));
   if (!override && fs.existsSync(destinationPath)) {
     // Skip.


### PR DESCRIPTION
## Ticket

[COMPASS-17](https://airtasker.atlassian.net/browse/COMPASS-17) — Change `spot` to be interacted with as a docker image rather than as a NodeJS tool

> **Stacked on #2711 → #2710 → #2709 → #2708.** Review those first. `build-and-test` is `on: pull_request: branches: [master]`, so it will not report here until the stack merges and GitHub retargets this PR.

## What

Two changes to `generate`, and one comment on `validation-server`.

## 1. Fail fast without a terminal

`generate` prompts for `--generator`, `--language` and `--out` when they are missing. That is fine at a shell. With no terminal — a CI step, a Gradle `exec`, `docker run` without `-it` — there is nothing for inquirer to read from, so the command either hangs until the job times out or accepts an empty answer and carries on with it.

Every call site in this ticket is about to become one of those. So:

```
$ node bin/run generate -c api.ts < /dev/null
 ›   Error: Cannot prompt for --generator (-g), --language (-l), --out (-o)
 ›   without a terminal. Pass every flag explicitly when running
 ›   non-interactively.
$ echo $?
2
```

**Every missing flag is named at once.** Reporting them one prompt at a time sends the caller round the loop three times, which is exactly what a CI turnaround is worst at. Interactive use is unchanged — the guard only fires when `process.stdin.isTTY` is falsy.

Exit code 2 distinguishes "your invocation is wrong" from the exit 1 that `generate` already uses for "this generator/language does not exist".

## 2. Report where the output actually went

`generate` now logs the absolute path it wrote:

```
Generated /repo/spots/doc/output/api.yml
```

Under a container the destination is the thing callers get wrong, and both failure modes are silent:

- An `-o` pointing outside the bind mount is written **inside the container** and the command exits 0. The file simply never appears on the host.
- `-o ~/x` tilde-expands against the **container's** home directory, not the caller's.

Neither is detectable from the exit code. Printing the resolved path is what makes them visible in the log.

The resolution moves out of `outputFile` into an exported `resolveOutputPath`, which `outputFile` then calls — so the path reported and the path written cannot drift apart. Note this changes `path.join` to `path.resolve`; for the arguments these call sites pass (`relativePath` is always a bare filename) the write target is identical, and `resolveOutputPath` is covered for the relative, absolute and `~` cases.

## 3. Mark the validation-server readiness line as interface

bff-client's Gradle `ExecFork` task blocks on the `Validation server running` prefix before it runs the contract tests. Rewording that line hangs that build until it times out, with no other signal. It now says so at the line.

> Plan note: the plan places this string in `lib/src/validation-server/server.ts`. It is actually in `cli/src/commands/validation-server.ts`.

## How this was verified

- `pnpm test` — 542 tests across 51 suites pass, 7 of them new.
- **Non-interactive guard**, through the built CLI with stdin redirected from `/dev/null`, not only through unit tests: all three flags missing names all three and exits 2; with `-g` and `-l` supplied it names only `--out`.
- **The full round trip from a directory with no `node_modules` on any parent path** — which is how the image will be invoked. `generate -c api.ts -g openapi3 -l yaml -o out` wrote `out/api.yml` and logged its absolute path; `ts-lint .` walked the tree and reported on it. Both exited as expected.
- `resolveOutputPath` has unit coverage for a relative directory, an absolute one, and `~`.

## Aside, for the docker PR

`parse()`'s type resolution is sensitive to the process working directory when the `@airtasker/spot` mapping resolves to **source** (`lib/src/lib.ts`, i.e. under ts-jest): the project then pulls in Spot's own sources, which need `@types/node` reachable from the cwd. It is not sensitive when the mapping resolves to the **built** `build/lib/src/lib.d.ts`, which is what the image ships — confirmed by the no-`node_modules` run above. Worth re-checking inside the container in the image PR rather than assuming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[COMPASS-17]: https://airtasker.atlassian.net/browse/COMPASS-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ