### PR TITLE
chore(release): v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ console.log(openApi);
 * [`spot init`](#spot-init)
 * [`spot lint SPOT_CONTRACT`](#spot-lint-spot_contract)
 * [`spot mock SPOT_CONTRACT`](#spot-mock-spot_contract)
+* [`spot ts-lint [DIRECTORY]`](#spot-ts-lint-directory)
 * [`spot validate SPOT_CONTRACT`](#spot-validate-spot_contract)
 * [`spot validation-server SPOT_CONTRACT`](#spot-validation-server-spot_contract)
 
@@ -276,7 +277,7 @@ EXAMPLE
   $ spot checksum api.ts
 ```
 
-_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/checksum.js)_
+_See code: [build/cli/src/commands/checksum.js](https://github.com/airtasker/spot/blob/v2.1.0/build/cli/src/commands/checksum.js)_
 
 ## `spot docs SPOT_CONTRACT`
 
@@ -297,7 +298,7 @@ EXAMPLE
   $ spot docs api.ts
 ```
 
-_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/docs.js)_
+_See code: [build/cli/src/commands/docs.js](https://github.com/airtasker/spot/blob/v2.1.0/build/cli/src/commands/docs.js)_
 
 ## `spot generate`
 
@@ -318,7 +319,7 @@ EXAMPLE
   $ spot generate --contract api.ts --language yaml --generator openapi3 --out output/
 ```
 
-_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/generate.js)_
+_See code: [build/cli/src/commands/generate.js](https://github.com/airtasker/spot/blob/v2.1.0/build/cli/src/commands/generate.js)_
 
 ## `spot help [COMMAND]`
 
@@ -356,7 +357,7 @@ EXAMPLE
   - package.json
 ```
 
-_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/init.js)_
+_See code: [build/cli/src/commands/init.js](https://github.com/airtasker/spot/blob/v2.1.0/build/cli/src/commands/init.js)_
 
 ## `spot lint SPOT_CONTRACT`
 
@@ -387,7 +388,7 @@ EXAMPLES
   $ spot lint --no-nullable-arrays=off
 ```
 
-_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/lint.js)_
+_See code: [build/cli/src/commands/lint.js](https://github.com/airtasker/spot/blob/v2.1.0/build/cli/src/commands/lint.js)_
 
 ## `spot mock SPOT_CONTRACT`
 
@@ -418,7 +419,29 @@ EXAMPLE
   $ spot mock api.ts
 ```
 
-_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/mock.js)_
+_See code: [build/cli/src/commands/mock.js](https://github.com/airtasker/spot/blob/v2.1.0/build/cli/src/commands/mock.js)_
+
+## `spot ts-lint [DIRECTORY]`
+
+Check the TypeScript in a Spot contract tree for formatting, lint and type errors
+
+```
+USAGE
+  $ spot ts-lint [DIRECTORY]
+
+ARGUMENTS
+  DIRECTORY  [default: .] directory to check
+
+OPTIONS
+  -h, --help  show CLI help
+  --fix       Reformat and apply lint fixes in place
+
+EXAMPLES
+  $ spot ts-lint
+  $ spot ts-lint spots --fix
+```
+
+_See code: [build/cli/src/commands/ts-lint.js](https://github.com/airtasker/spot/blob/v2.1.0/build/cli/src/commands/ts-lint.js)_
 
 ## `spot validate SPOT_CONTRACT`
 
@@ -438,7 +461,7 @@ EXAMPLE
   $ spot validate api.ts
 ```
 
-_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/validate.js)_
+_See code: [build/cli/src/commands/validate.js](https://github.com/airtasker/spot/blob/v2.1.0/build/cli/src/commands/validate.js)_
 
 ## `spot validation-server SPOT_CONTRACT`
 
@@ -459,7 +482,7 @@ EXAMPLE
   $ spot validation-server api.ts
 ```
 
-_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v2.0.3/build/cli/src/commands/validation-server.js)_
+_See code: [build/cli/src/commands/validation-server.js](https://github.com/airtasker/spot/blob/v2.1.0/build/cli/src/commands/validation-server.js)_
 <!-- commandsstop -->
 
 # Releases

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@airtasker/spot",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "author": "Francois Wouts, Leslie Fung",
   "bin": {
     "spot": "./bin/run"


### PR DESCRIPTION
## Release v2.1.0

Version bump so a GitHub Release can be cut. Follows the [wiki release process](https://github.com/airtasker/spot/wiki/Releasing-Spot): bump `version` in `package.json`, run `prepack` to refresh the README, PR, squash-merge.

## Why minor, not patch

`2.0.3` → `2.1.0`. The release **adds a command** — `spot ts-lint` — which is new API surface, so patch would be wrong.

Nothing in it is breaking. The parser change corrects a path mapping that only ever resolved through a consumer's *installed* copy of `@airtasker/spot`; a consumer that has one resolves to the same declarations it did before.

## What this release carries

All of [COMPASS-17](https://airtasker.atlassian.net/browse/COMPASS-17):

| | |
|---|---|
| [#2708](https://github.com/airtasker/spot/pull/2708) | Parser resolves `@airtasker/spot` from Spot's own tree — contracts no longer need an installed copy beside them |
| [#2709](https://github.com/airtasker/spot/pull/2709) | Lint stack moved to eslint flat config on eslint 10 |
| [#2710](https://github.com/airtasker/spot/pull/2710) | Declared the two oclif packages `bin/run` needs at runtime — **the CLI could not start at all under pnpm's isolated `node_modules`** |
| [#2711](https://github.com/airtasker/spot/pull/2711) | **`spot ts-lint [directory] [--fix]`** — formatting, lint and type checks under bundled configuration |
| [#2712](https://github.com/airtasker/spot/pull/2712) | `generate` exits 2 naming every missing flag when there is no terminal, instead of hanging on a prompt nothing can answer |
| [#2713](https://github.com/airtasker/spot/pull/2713) | `ghcr.io/airtasker/spot` image + the `docker-parity` gate |
| [#2714](https://github.com/airtasker/spot/pull/2714) | Image publishes from the same GitHub Release event as npm |

## README changes are all generated

`prepack` rewrote the `<!-- toc -->` and `<!-- commands -->` blocks:

- `spot ts-lint [DIRECTORY]` is documented for the first time
- every `blob/v2.0.3/…` source link became `blob/v2.1.0/…`

The hand-written Docker and Releases sections sit **outside** the oclif markers and are untouched — I checked rather than assumed, since that is exactly what a regeneration step tends to eat.

## How this was verified

- `pnpm test` — **551 tests across 53 suites pass**.
- `pnpm lint:check` — **0 errors**. (25 warnings, all pre-existing on master and untouched by a version bump.)
- **The image built from this commit reports `@airtasker/spot/2.1.0`**, and `scripts/check-image-parity` passes against it end to end — the same script the `docker-parity` gate runs, including the self-containment and validation-server checks.
- `git grep` finds no remaining `2.0.3` outside `pnpm-lock.yaml` and `docs/`.

## Steps to merge, then release

1. Squash-merge this PR.
2. Draft a release tagged **`v2.1.0`** — the `v` prefix is required.
3. Publishing it starts three jobs in parallel: npm publish, the GitHub Packages copy, and `docker-publish`. They can fail independently; if npm lands and ghcr does not, re-run `docker-publish` rather than cutting a new version.
4. **Then the manual ghcr checklist**, which nothing automates: this repo is public, so the package defaults to **public** on first push. Flip `ghcr.io/airtasker/spot` to **private**, grant `read:packages` to the three consumer repos' CI tokens, and pull-test from an arm64 laptop and with a consumer token before the consumer PRs are un-drafted.
5. The consumer stacks are open as drafts and pin `ghcr.io/airtasker/spot:2.1.0`, in the order enrichment-engine → bff-client → rails-monolith.

## Two notes on the wiki page

Worth someone updating it — neither blocks this PR:

- It says run **`yarn prepack`**. This repo is pnpm-only (`packageManager: pnpm@10.28.1`, and `pnpm-workspace.yaml` carries supply-chain settings), so I ran `pnpm prepack`.
- It says the `v` tag triggers **NPM publication via CircleCI**. Publishing moved to GitHub Actions — `publish` in `.github/workflows/build-and-test.yml`, gated on `github.event_name == 'release'`. The `v` prefix still matters, but now because `docker/metadata-action`'s `type=semver` patterns parse it.

I also used the commit format from this repo's own history (`chore(release): v2.0.3`, #2594) rather than the wiki's `Release v2.1.0`, since it satisfies Conventional Commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[COMPASS-17]: https://airtasker.atlassian.net/browse/COMPASS-17?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ