### PR TITLE
build(COMPASS-28): declare @types/node and move to typescript 5.9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Spot is a TypeScript-based API contract definition tool that generates OpenAPI, 
 ### TypeScript Configuration
 - Strict TypeScript settings enabled
 - Experimental decorators enabled for syntax support
-- Builds to CommonJS modules targeting ES2019
+- Builds to CommonJS modules targeting ES2022, with `useDefineForClassFields` off so class-field semantics stay as they were
 - Path mapping: `@airtasker/spot` → `./lib/src/lib`
 
 ### Testing

--- a/cli/src/commands/ts-lint.spec.ts
+++ b/cli/src/commands/ts-lint.spec.ts
@@ -13,7 +13,9 @@ const FIXTURES = path.join(__dirname, "../../../test-fixtures/ts-lint");
 describe("ts-lint command", () => {
   jest.setTimeout(60000);
 
-  let restoreExitCode: number | undefined;
+  // Typed off the property rather than spelled out: node widened `exitCode` to
+  // allow a string and null, and this is only ever a saved copy of it.
+  let restoreExitCode: typeof process.exitCode;
   let out: string;
   let writeSpy: jest.SpyInstance;
 

--- a/lib/src/spec-helpers/helper.spec.ts
+++ b/lib/src/spec-helpers/helper.spec.ts
@@ -1,0 +1,28 @@
+import { createSourceFile } from "./helper";
+
+describe("createSourceFile", () => {
+  /**
+   * `validateProject` rejects a source file with any pre-emit diagnostic, and
+   * every parser and linting spec leans on it to reject a bad fixture. The
+   * options it checks under come from `contractCompilerOptions`, which includes
+   * `skipLibCheck`, so the gate is narrower than "no diagnostics at all" — these
+   * two cases pin that it still fails on an error in the contract itself.
+   */
+  it("rejects a contract with a type error", () => {
+    expect(() =>
+      createSourceFile({
+        path: "main",
+        content: 'export const answer: number = "forty-two";\n'
+      })
+    ).toThrow();
+  });
+
+  it("accepts a contract that type-checks", () => {
+    expect(() =>
+      createSourceFile({
+        path: "main",
+        content: "export const answer: number = 42;\n"
+      })
+    ).not.toThrow();
+  });
+});

--- a/lib/src/spec-helpers/helper.ts
+++ b/lib/src/spec-helpers/helper.ts
@@ -1,5 +1,5 @@
-import * as path from "path";
-import { Project, SourceFile, ts } from "ts-morph";
+import { Project, SourceFile } from "ts-morph";
+import { contractCompilerOptions } from "../ts-project";
 
 /**
  * Create an AST source file. Any files imported from the main file must also be provided.
@@ -40,23 +40,12 @@ interface FileDetail {
 export function createProject(): Project {
   return new Project({
     compilerOptions: {
-      target: ts.ScriptTarget.ESNext,
-      module: ts.ModuleKind.CommonJS,
-      strict: true,
-      noImplicitAny: true,
-      strictNullChecks: true,
-      strictFunctionTypes: true,
-      strictPropertyInitialization: true,
-      noImplicitThis: true,
-      alwaysStrict: true,
-      noImplicitReturns: true,
-      noFallthroughCasesInSwitch: true,
-      moduleResolution: ts.ModuleResolutionKind.NodeJs,
-      experimentalDecorators: true,
-      baseUrl: "./",
-      paths: {
-        "@airtasker/spot": [path.join(__dirname, "../lib")]
-      }
+      // Contracts are parsed under the same options `createContractProject`
+      // uses, so a spec and the command it stands in for agree on the compiler
+      // settings. The `@airtasker/spot` mapping needs no override: it is an
+      // absolute path resolved when that module loads, so it points at the same
+      // declarations from here.
+      ...contractCompilerOptions
     }
   });
 }

--- a/lib/src/util.spec.ts
+++ b/lib/src/util.spec.ts
@@ -1,0 +1,42 @@
+import { err, ok, Result } from "./util";
+
+describe("Result", () => {
+  /**
+   * `Ok.isErr` and `Err.isOk` both return `this is never` rather than `boolean`,
+   * and that is what lets a `Result` narrow through a method call — the shape
+   * every parser in `lib/src/parsers` is written in. Narrowing a union by a
+   * method call needs *every* member of the union to answer with a type
+   * predicate; one member answering `boolean` costs the call its type
+   * information, leaving the value un-narrowed in both branches.
+   *
+   * What is under test is the narrowing, so the failure is a compile error
+   * rather than a failed expectation: widen either return type back to
+   * `boolean` and this file stops type-checking, which ts-jest reports as a
+   * failing suite. The two helpers below narrow through different methods, so
+   * each pins one method and neither covers the other.
+   */
+  const narrowViaIsErr = (r: Result<number, Error>): Result<string, Error> => {
+    // Needs `r` to narrow to `Err`, or an `Err<Error>` is not assignable to a
+    // `Result<string, Error>`. Pins `Ok.isErr`.
+    if (r.isErr()) return r;
+    return ok(String(r.unwrap()));
+  };
+
+  const narrowViaIsOk = (r: Result<number, Error>): string => {
+    if (r.isOk()) return String(r.unwrap());
+    // Needs `r` to narrow to `Err`, or `unwrapErr` is not a property of the
+    // union. Pins `Err.isOk`.
+    return r.unwrapErr().message;
+  };
+
+  it("narrows to Ok when the value is present", () => {
+    expect(narrowViaIsErr(ok(7)).unwrapOrThrow()).toBe("7");
+    expect(narrowViaIsOk(ok(7))).toBe("7");
+  });
+
+  it("narrows to Err when the error is present", () => {
+    const failure: Result<number, Error> = err(new Error("no value"));
+    expect(narrowViaIsErr(failure).unwrapErrOrThrow().message).toBe("no value");
+    expect(narrowViaIsOk(failure)).toBe("no value");
+  });
+});

--- a/lib/src/util.ts
+++ b/lib/src/util.ts
@@ -75,7 +75,16 @@ class Ok<T> {
     return true;
   }
 
-  isErr(): boolean {
+  /**
+   * `this is never` rather than `boolean`, because the return type is what makes
+   * `Result` narrow. A caller writes `if (r.isErr()) return r;` and then reaches for
+   * `r.unwrap()`; narrowing a union by a method call needs every member of that union
+   * to answer with a type predicate. When one member answers `boolean` the call
+   * carries no type information, so `r` stays `Ok<T> | Err<E>` in both branches: the
+   * early return stops being assignable to the caller's `Result`, and `unwrap` stops
+   * being visible. An `Ok` is never an error, so the narrowed type here is `never`.
+   */
+  isErr(): this is never {
     return false;
   }
 
@@ -105,7 +114,8 @@ class Err<E extends Error> {
     this.value = value;
   }
 
-  isOk(): boolean {
+  // A type predicate for the same reason as `Ok.isErr` above. An `Err` is never ok.
+  isOk(): this is never {
     return false;
   }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "qs": "^6.15.3",
     "randomstring": "^1.3.1",
     "ts-morph": "18.0.0",
-    "typescript": "^4.9.5",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.67.0",
     "validator": "^13.12.0"
   },
@@ -40,6 +40,7 @@
     "@types/inquirer": "^8.1.2",
     "@types/jest": "^29.5.0",
     "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.20.1",
     "@types/qs": "^6.15.1",
     "@types/randomstring": "^1.3.0",
     "@types/supertest": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,11 +73,11 @@ importers:
         specifier: 18.0.0
         version: 18.0.0
       typescript:
-        specifier: ^4.9.5
-        version: 4.9.5
+        specifier: ^5.9.3
+        version: 5.9.3
       typescript-eslint:
         specifier: ^8.67.0
-        version: 8.67.0(eslint@10.8.1)(typescript@4.9.5)
+        version: 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       validator:
         specifier: ^13.12.0
         version: 13.12.0
@@ -106,6 +106,9 @@ importers:
       '@types/js-yaml':
         specifier: ^4.0.9
         version: 4.0.9
+      '@types/node':
+        specifier: ^22.20.1
+        version: 22.20.1
       '@types/qs':
         specifier: ^6.15.1
         version: 6.15.1
@@ -120,13 +123,13 @@ importers:
         version: 13.11.10
       eslint-plugin-jest:
         specifier: ^29.16.1
-        version: 29.16.1(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(jest@29.7.0(@types/node@20.8.4)(node-notifier@8.0.2))(typescript@4.9.5)
+        version: 29.16.1(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(jest@29.7.0(@types/node@22.20.1)(node-notifier@8.0.2))(typescript@5.9.3)
       globals:
         specifier: ^17.9.0
         version: 17.9.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@20.8.4)(node-notifier@8.0.2)
+        version: 29.7.0(@types/node@22.20.1)(node-notifier@8.0.2)
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
@@ -138,7 +141,7 @@ importers:
         version: 7.2.2
       ts-jest:
         specifier: ^29.4.12
-        version: 29.4.12(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.8.4)(node-notifier@8.0.2))(typescript@4.9.5)
+        version: 29.4.12(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1)(node-notifier@8.0.2))(typescript@5.9.3)
 
   docs:
     devDependencies:
@@ -920,8 +923,8 @@ packages:
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
 
-  '@types/node@20.8.4':
-    resolution: {integrity: sha512-ZVPnqU58giiCjSxjVUESDtdPk4QR5WQhhINbc9UBrKLU68MX5BF6kbQzTrkwbolyr0X8ChBpXfavr5mZFKZQ5A==}
+  '@types/node@22.20.1':
+    resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -3770,11 +3773,6 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@4.9.5:
-    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -3785,8 +3783,8 @@ packages:
     engines: {node: '>=0.8.0'}
     hasBin: true
 
-  undici-types@5.25.3:
-    resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -4470,7 +4468,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -4483,14 +4481,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.8.4)
+      jest-config: 29.7.0(@types/node@22.20.1)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -4517,7 +4515,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -4535,7 +4533,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -4557,7 +4555,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -4629,7 +4627,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.4
       '@types/istanbul-reports': 3.0.2
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -5072,17 +5070,17 @@ snapshots:
   '@types/body-parser@1.19.3':
     dependencies:
       '@types/connect': 3.4.36
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/connect@3.4.36':
     dependencies:
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/cookiejar@2.1.5': {}
 
   '@types/cors@2.8.17':
     dependencies:
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/eslint-scope@3.7.7':
     dependencies:
@@ -5100,7 +5098,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.17.37':
     dependencies:
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.5
       '@types/send': 0.17.2
@@ -5115,16 +5113,16 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.2
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 5.1.2
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/graceful-fs@4.1.7':
     dependencies:
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/html-minifier-terser@6.1.0': {}
 
@@ -5158,7 +5156,7 @@ snapshots:
 
   '@types/jsonfile@6.1.2':
     dependencies:
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/methods@1.1.4': {}
 
@@ -5168,9 +5166,9 @@ snapshots:
 
   '@types/minimatch@5.1.2': {}
 
-  '@types/node@20.8.4':
+  '@types/node@22.20.1':
     dependencies:
-      undici-types: 5.25.3
+      undici-types: 6.21.0
 
   '@types/prop-types@15.7.15': {}
 
@@ -5196,13 +5194,13 @@ snapshots:
   '@types/send@0.17.2':
     dependencies:
       '@types/mime': 1.3.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/serve-static@1.15.3':
     dependencies:
       '@types/http-errors': 2.0.2
       '@types/mime': 3.0.2
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/stack-utils@2.0.1': {}
 
@@ -5210,7 +5208,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       form-data: 4.0.5
 
   '@types/supertest@6.0.3':
@@ -5220,7 +5218,7 @@ snapshots:
 
   '@types/through@0.0.31':
     dependencies:
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -5235,40 +5233,40 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.1
 
-  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(typescript@4.9.5)':
+  '@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@4.9.5)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.67.0
-      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1)(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@4.9.5)
+      '@typescript-eslint/type-utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.67.0
       eslint: 10.8.1
       ignore: 7.0.6
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@4.9.5)':
+  '@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.67.0
       '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/typescript-estree': 8.67.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.8.1
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.67.0(typescript@4.9.5)':
+  '@typescript-eslint/project-service@8.67.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@4.9.5)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.67.0
       debug: 4.4.3(supports-color@5.5.0)
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5277,47 +5275,47 @@ snapshots:
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/visitor-keys': 8.67.0
 
-  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@4.9.5)':
+  '@typescript-eslint/tsconfig-utils@8.67.0(typescript@5.9.3)':
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1)(typescript@4.9.5)':
+  '@typescript-eslint/type-utils@8.67.0(eslint@10.8.1)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/typescript-estree': 8.67.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
       eslint: 10.8.1
-      ts-api-utils: 2.5.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.67.0': {}
 
-  '@typescript-eslint/typescript-estree@8.67.0(typescript@4.9.5)':
+  '@typescript-eslint/typescript-estree@8.67.0(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.67.0(typescript@4.9.5)
-      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@4.9.5)
+      '@typescript-eslint/project-service': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.67.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/visitor-keys': 8.67.0
       debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@4.9.5)
-      typescript: 4.9.5
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.67.0(eslint@10.8.1)(typescript@4.9.5)':
+  '@typescript-eslint/utils@8.67.0(eslint@10.8.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.1)
       '@typescript-eslint/scope-manager': 8.67.0
       '@typescript-eslint/types': 8.67.0
-      '@typescript-eslint/typescript-estree': 8.67.0(typescript@4.9.5)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
       eslint: 10.8.1
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5910,13 +5908,13 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  create-jest@29.7.0(@types/node@20.8.4):
+  create-jest@29.7.0(@types/node@22.20.1):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.8.4)
+      jest-config: 29.7.0(@types/node@22.20.1)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -6162,14 +6160,14 @@ snapshots:
     dependencies:
       eslint: 10.8.1
 
-  eslint-plugin-jest@29.16.1(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(jest@29.7.0(@types/node@20.8.4)(node-notifier@8.0.2))(typescript@4.9.5):
+  eslint-plugin-jest@29.16.1(@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(jest@29.7.0(@types/node@22.20.1)(node-notifier@8.0.2))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@4.9.5)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       eslint: 10.8.1
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(typescript@4.9.5)
-      jest: 29.7.0(@types/node@20.8.4)(node-notifier@8.0.2)
-      typescript: 4.9.5
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(typescript@5.9.3)
+      jest: 29.7.0(@types/node@22.20.1)(node-notifier@8.0.2)
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6849,7 +6847,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.1
@@ -6869,16 +6867,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@20.8.4)(node-notifier@8.0.2):
+  jest-cli@29.7.0(@types/node@22.20.1)(node-notifier@8.0.2):
     dependencies:
       '@jest/core': 29.7.0(node-notifier@8.0.2)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.8.4)
+      create-jest: 29.7.0(@types/node@22.20.1)
       exit: 0.1.2
       import-local: 3.1.0
-      jest-config: 29.7.0(@types/node@20.8.4)
+      jest-config: 29.7.0(@types/node@22.20.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -6890,7 +6888,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@20.8.4):
+  jest-config@29.7.0(@types/node@22.20.1):
     dependencies:
       '@babel/core': 7.23.2
       '@jest/test-sequencer': 29.7.0
@@ -6915,7 +6913,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -6944,7 +6942,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -6954,7 +6952,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.7
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -7000,7 +6998,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -7035,7 +7033,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -7063,7 +7061,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -7109,7 +7107,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -7128,7 +7126,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -7137,23 +7135,23 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 20.8.4
+      '@types/node': 22.20.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@20.8.4)(node-notifier@8.0.2):
+  jest@29.7.0(@types/node@22.20.1)(node-notifier@8.0.2):
     dependencies:
       '@jest/core': 29.7.0(node-notifier@8.0.2)
       '@jest/types': 29.6.3
       import-local: 3.1.0
-      jest-cli: 29.7.0(@types/node@20.8.4)(node-notifier@8.0.2)
+      jest-cli: 29.7.0(@types/node@22.20.1)(node-notifier@8.0.2)
     optionalDependencies:
       node-notifier: 8.0.2
     transitivePeerDependencies:
@@ -8333,22 +8331,22 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  ts-api-utils@2.5.0(typescript@4.9.5):
+  ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
 
-  ts-jest@29.4.12(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@20.8.4)(node-notifier@8.0.2))(typescript@4.9.5):
+  ts-jest@29.4.12(@babel/core@7.28.6)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.6))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.20.1)(node-notifier@8.0.2))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@20.8.4)(node-notifier@8.0.2)
+      jest: 29.7.0(@types/node@22.20.1)(node-notifier@8.0.2)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
       semver: 7.8.5
       type-fest: 4.41.0
-      typescript: 4.9.5
+      typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.28.6
@@ -8407,25 +8405,23 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typescript-eslint@8.67.0(eslint@10.8.1)(typescript@4.9.5):
+  typescript-eslint@8.67.0(eslint@10.8.1)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@4.9.5))(eslint@10.8.1)(typescript@4.9.5)
-      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@4.9.5)
-      '@typescript-eslint/typescript-estree': 8.67.0(typescript@4.9.5)
-      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@4.9.5)
+      '@typescript-eslint/eslint-plugin': 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.8.1)(typescript@5.9.3))(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@10.8.1)(typescript@5.9.3)
       eslint: 10.8.1
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@4.9.5: {}
 
   typescript@5.9.3: {}
 
   uglify-js@3.19.3:
     optional: true
 
-  undici-types@5.25.3: {}
+  undici-types@6.21.0: {}
 
   universalify@0.1.2: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,15 @@
 
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    // Optional chaining was introduced in es2020. This project supports node >= 12. Only node >= 14 supports optional chaining.
-    "target": "es2019",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    // Every runtime the package supports implements es2022 in full — see the floor in
+    // `engines.node` — so nothing here is downlevelled for a runtime that needs it.
+    "target": "es2022",
+    // `target: es2022` would otherwise turn this on, which changes what a class
+    // field is: a declared-but-unassigned field becomes an own enumerable
+    // property. `ParserError` and its siblings are exported, and that shows up
+    // in what a consumer gets from `JSON.stringify` on one — `message` appears
+    // where it did not before. Emit follows the target; field semantics do not.
+    "useDefineForClassFields": false,                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
## Ticket

[COMPASS-28](https://airtasker.atlassian.net/browse/COMPASS-28) — Bump `spot`'s NodeJS minimum from 18 to 22

> **PR 2 of 9. Staying in draft** until the whole chain is verified, per the request on #2718. Based on `master` with #2718 merged.

## Why

`@types/node` was **not declared anywhere**. It resolved transitively through jest at `20.8.4`, so the package type-checked against Node 20 lib definitions while `engines` claimed 22. Declaring it forces the compiler bump — every current `@types/node` major sets `typeScriptVersion: 5.6`.

Two deliberate version choices:

- **`@types/node@^22`, the floor rather than the newest (26.2.0).** Type-checking against the *oldest* supported runtime is what makes the compiler reject an API that is missing on it. Pinning to the newest would let a Node 26-only API compile and then fail at runtime on 22.
- **`typescript@^5.9.3` and no further.** `typescript-eslint` peer-depends on `>=4.8.4 <6.1.0` and has **no release above v8**, so TypeScript 6.1+ cannot be used while `ts-lint` ships `typescript-eslint`. This is why Dependabot #2685 (`typescript` → 7.0.2) can never merge as proposed.

## Three things the bump surfaced

**1. `Result` stopped narrowing — 119 errors across 14 parser files.**

`Ok.isErr` and `Err.isOk` returned `boolean`. Narrowing a union by a method call needs *every* member of that union to answer with a type predicate; one member answering `boolean` costs the call its type information, leaving the value un-narrowed in both branches. That showed up in two shapes, both visible in the build output:

```
error TS2322: Type 'Result<Type, ParserError>' is not assignable to type 'Result<Body, ParserError>'
error TS2339: Property 'unwrap' does not exist on type 'Result<Type, ParserError>'
```

The first is the `if (r.isErr()) return r;` early return; the second is the `r.unwrap()` after it. Both are fixed by two return types in `util.ts`, with **no call-site changes** — the alternative was rewriting 65 call sites onto the standalone `isErr()` guard.

Confirmed by compiling the same reduction under 4.9.5 (clean) and 5.9.3 (fails), and confirmed that the standalone guard was unaffected — so this is the method-call form specifically, not `Result` in general.

**2. The spec helper's compiler options had drifted from the CLI's.**

`createProject()` in `lib/src/spec-helpers/helper.ts` duplicated `contractCompilerOptions` but was missing `skipLibCheck` and `resolveJsonModule` — so specs type-checked contracts under settings the real command does not use. That drift is what made `@types/node@22` fail every generator spec: **ts-morph 18 vendors TypeScript 5.0.2**, which cannot resolve `CompressionStream` in `@types/node/web-globals/streams.d.ts`, and only the CLI path suppressed it.

It now spreads `contractCompilerOptions` and overrides just the `@airtasker/spot` mapping, so the duplication cannot drift again. The underlying version skew disappears when ts-morph moves (PR 8).

**3. `process.exitCode` widened** to `string | number | null | undefined`, which the ts-lint command's spec was saving into a `number | undefined`. Now typed off the property itself so it cannot drift again.

## Guarding the invariant

`util.ts` now carries a comment saying those two return types are load-bearing, so `lib/src/util.spec.ts` pins each one with its own case. Mutation-tested both arms independently:

| Mutation | Suite |
|---|---|
| `Ok.isErr` → `boolean` | **fails** |
| `Err.isOk` → `boolean` | **fails** |
| neither | passes |

The first version of that test only caught the `Ok.isErr` mutation, which is why there are two helpers narrowing through different methods rather than one.

## How this was verified

Locally on Node 22.23.2, all exit 0:

| Check | Result |
|---|---|
| `pnpm build` | 0 — was 119 errors before the `util.ts` fix |
| `pnpm test` | 0 — 54 suites, 553 tests, 44 snapshots |
| `pnpm lint:check` | 0 |
| `pnpm build-docs` | 0 |
| `docker build` + `check-image-parity` | 0 — all checks passed |
| `validate` / `lint` / `ts-lint` / `checksum` / `generate` | 0, with `ts-lint` 0 on `clean` and 1 on `dirty` |

**Generated output is unchanged.** All seven generator × language combinations from `test-fixtures/contract/api.ts` are byte-identical between `master` and this branch:

```
diff -r /tmp/spot-before /tmp/spot-after   # empty
```

Expected, since contracts are parsed by ts-morph's vendored compiler rather than this one — but the `target` moved from es2019 to es2022, so it was worth confirming rather than assuming.


[COMPASS-28]: https://airtasker.atlassian.net/browse/COMPASS-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ